### PR TITLE
フォームのコントロール群の名前におけるマジック文字列にキャメルケースを適用

### DIFF
--- a/MSBT_Editor/Form1.Designer.cs
+++ b/MSBT_Editor/Form1.Designer.cs
@@ -32,11 +32,11 @@ namespace MSBT_Editor
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
             this.stbStatusBar = new System.Windows.Forms.StatusStrip();
             this.stbStatusLabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.stbOpenedMSBTName = new System.Windows.Forms.ToolStripStatusLabel();
+            this.stbOpenedMsbtName = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusLabel3 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.stbOpenedMSBFName = new System.Windows.Forms.ToolStripStatusLabel();
+            this.stbOpenedMsbfName = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusLabel5 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.stbOpenedRARCName = new System.Windows.Forms.ToolStripStatusLabel();
+            this.stbOpenedRarcName = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusLabel8 = new System.Windows.Forms.ToolStripStatusLabel();
             this.stbSavedFilePathLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.stbSavedFilePath = new System.Windows.Forms.ToolStripStatusLabel();
@@ -54,31 +54,31 @@ namespace MSBT_Editor
             this.ARC開くToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ARC上書き保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ARC保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.lstListsInsideMSBT = new System.Windows.Forms.ListBox();
-            this.txtMSBTText = new System.Windows.Forms.TextBox();
+            this.lstListsInsideMsbt = new System.Windows.Forms.ListBox();
+            this.txtMsbtText = new System.Windows.Forms.TextBox();
             this.textBox2 = new System.Windows.Forms.TextBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
-            this.tbpMSBTSettings = new System.Windows.Forms.TabPage();
-            this.gbxMSBTSettingsATR1 = new System.Windows.Forms.GroupBox();
-            this.lblATR1SpecialText = new System.Windows.Forms.Label();
-            this.txtATR1SpecialText = new System.Windows.Forms.TextBox();
-            this.lblATR1Unknown6 = new System.Windows.Forms.Label();
-            this.lblATR1MessageAreaID = new System.Windows.Forms.Label();
-            this.lblATR1EventCameraID = new System.Windows.Forms.Label();
-            this.lblATR1WindowID = new System.Windows.Forms.Label();
-            this.lblATR1DialogID = new System.Windows.Forms.Label();
-            this.lblATR1SimpleCamID = new System.Windows.Forms.Label();
-            this.lblATR1SoundID = new System.Windows.Forms.Label();
-            this.txtATR1Unknown6 = new System.Windows.Forms.TextBox();
-            this.txtATR1MessageAreaID = new System.Windows.Forms.TextBox();
-            this.txtATR1EventCameraID = new System.Windows.Forms.TextBox();
-            this.txtATR1WindowID = new System.Windows.Forms.TextBox();
-            this.txtATR1DialogID = new System.Windows.Forms.TextBox();
-            this.txtATR1SimpleCamID = new System.Windows.Forms.TextBox();
-            this.txtATR1SoundID = new System.Windows.Forms.TextBox();
-            this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.tbpMsbtSetting = new System.Windows.Forms.TabPage();
+            this.gbxMsbtSettingsAtr1 = new System.Windows.Forms.GroupBox();
+            this.lblAtr1SpecialText = new System.Windows.Forms.Label();
+            this.txtAtr1SpecialText = new System.Windows.Forms.TextBox();
+            this.lblAtr1Unknown6 = new System.Windows.Forms.Label();
+            this.lblAtr1MessageAreaID = new System.Windows.Forms.Label();
+            this.lblAtr1EventCameraID = new System.Windows.Forms.Label();
+            this.lblAtr1WindowID = new System.Windows.Forms.Label();
+            this.lblAtr1DialogID = new System.Windows.Forms.Label();
+            this.lblAtr1SimpleCamID = new System.Windows.Forms.Label();
+            this.lblAtr1SoundID = new System.Windows.Forms.Label();
+            this.txtAtr1Unknown6 = new System.Windows.Forms.TextBox();
+            this.txtAtr1MessageAreaID = new System.Windows.Forms.TextBox();
+            this.txtAtr1EventCameraID = new System.Windows.Forms.TextBox();
+            this.txtAtr1WindowID = new System.Windows.Forms.TextBox();
+            this.txtAtr1DialogID = new System.Windows.Forms.TextBox();
+            this.txtAtr1SimpleCamID = new System.Windows.Forms.TextBox();
+            this.txtAtr1SoundID = new System.Windows.Forms.TextBox();
+            this.tbpMsbtTextEdit = new System.Windows.Forms.TabPage();
             this.tabControl2 = new System.Windows.Forms.TabControl();
-            this.tabPage6 = new System.Windows.Forms.TabPage();
+            this.tbpGeneralTag = new System.Windows.Forms.TabPage();
             this.btnInsertColorTag = new System.Windows.Forms.Button();
             this.btnInsertPlayerCharacterTag = new System.Windows.Forms.Button();
             this.cmbCenterTag = new System.Windows.Forms.ComboBox();
@@ -88,7 +88,7 @@ namespace MSBT_Editor
             this.cmbFontSizeTag = new System.Windows.Forms.ComboBox();
             this.btnInsertFontSizeTag = new System.Windows.Forms.Button();
             this.cmbLineControlTag = new System.Windows.Forms.ComboBox();
-            this.tabPage7 = new System.Windows.Forms.TabPage();
+            this.tbpValueTag = new System.Windows.Forms.TabPage();
             this.gbxTimerTag = new System.Windows.Forms.GroupBox();
             this.btnInsertTimerTag = new System.Windows.Forms.Button();
             this.lblTimerTagDelayTime = new System.Windows.Forms.Label();
@@ -100,7 +100,7 @@ namespace MSBT_Editor
             this.lblRubiTagRubiCount = new System.Windows.Forms.Label();
             this.txtRubiTagRubiCount = new System.Windows.Forms.TextBox();
             this.txtRubiTagKanjiCount = new System.Windows.Forms.TextBox();
-            this.tabPage8 = new System.Windows.Forms.TabPage();
+            this.tbpSpecialTag = new System.Windows.Forms.TabPage();
             this.gbxSpecialTag = new System.Windows.Forms.GroupBox();
             this.btnInsertTotalPlayTimeTag = new System.Windows.Forms.Button();
             this.btnInsertUserNameTag = new System.Windows.Forms.Button();
@@ -115,7 +115,7 @@ namespace MSBT_Editor
             this.btnInsertVariableInt3DigitsTag = new System.Windows.Forms.Button();
             this.btnInsertResultScenarioNameTag = new System.Windows.Forms.Button();
             this.btnInsertResultGalaxyNameTag = new System.Windows.Forms.Button();
-            this.tabPage9 = new System.Windows.Forms.TabPage();
+            this.tbpIconTag = new System.Windows.Forms.TabPage();
             this.btnInsertOthersIconTag = new System.Windows.Forms.Button();
             this.cmbOthersIconTag = new System.Windows.Forms.ComboBox();
             this.lblOthersIconTag = new System.Windows.Forms.Label();
@@ -137,56 +137,56 @@ namespace MSBT_Editor
             this.lblCustomIconTagDiscription1 = new System.Windows.Forms.Label();
             this.txtCustomIconHex = new System.Windows.Forms.TextBox();
             this.tbpListEdit = new System.Windows.Forms.TabPage();
-            this.gbxListEditFEN1 = new System.Windows.Forms.GroupBox();
-            this.btnDeleteFEN1List = new System.Windows.Forms.Button();
-            this.btnAddFEN1List = new System.Windows.Forms.Button();
-            this.txtFEN1ListName = new System.Windows.Forms.TextBox();
-            this.lblFEN1ListName = new System.Windows.Forms.Label();
-            this.gbxListEditFLW2 = new System.Windows.Forms.GroupBox();
-            this.btnDeleteFLW2List = new System.Windows.Forms.Button();
-            this.btnAddFLW2List = new System.Windows.Forms.Button();
-            this.lblFLW2ListEditDiscription = new System.Windows.Forms.Label();
-            this.gbxListEditMSBT = new System.Windows.Forms.GroupBox();
-            this.lblMSBTListEditDiscription = new System.Windows.Forms.Label();
-            this.lblMSBTListName = new System.Windows.Forms.Label();
-            this.txtSelectedMSBTListName = new System.Windows.Forms.TextBox();
-            this.lblMSBTListEditNote = new System.Windows.Forms.Label();
-            this.btnDeleteMSBTList = new System.Windows.Forms.Button();
-            this.txtMSBTListName = new System.Windows.Forms.TextBox();
-            this.btnAddMSBTList = new System.Windows.Forms.Button();
-            this.tbpMSBFSetting = new System.Windows.Forms.TabPage();
-            this.chkShowTvwMSBFFlow = new System.Windows.Forms.CheckBox();
-            this.btnReloadTvwMSBFFlow = new System.Windows.Forms.Button();
-            this.txtReadOnlyMSBTText = new System.Windows.Forms.TextBox();
-            this.lblMSBFFlow = new System.Windows.Forms.Label();
-            this.tvwMSBFFlow = new System.Windows.Forms.TreeView();
-            this.lblMSBFSettingNote = new System.Windows.Forms.Label();
-            this.gbxFEN1 = new System.Windows.Forms.GroupBox();
-            this.lblFLW2StartIndex = new System.Windows.Forms.Label();
-            this.lblFEN1Arg0 = new System.Windows.Forms.Label();
-            this.txtFEN1StartIndex = new System.Windows.Forms.TextBox();
-            this.txtFEN1Arg0 = new System.Windows.Forms.TextBox();
-            this.gbxFLW2 = new System.Windows.Forms.GroupBox();
-            this.label41 = new System.Windows.Forms.Label();
-            this.gbxFLW2Branch = new System.Windows.Forms.GroupBox();
-            this.txtFLW2BranchFalse = new System.Windows.Forms.TextBox();
-            this.txtFLW2BranchTrue = new System.Windows.Forms.TextBox();
-            this.lblFLW2BranchFalse = new System.Windows.Forms.Label();
-            this.lblFLW2BranchTrue = new System.Windows.Forms.Label();
-            this.lblFLW2Arg4 = new System.Windows.Forms.Label();
-            this.lblFLW2Arg3 = new System.Windows.Forms.Label();
-            this.lblFLW2Arg2 = new System.Windows.Forms.Label();
-            this.lblFLW2Arg1 = new System.Windows.Forms.Label();
-            this.txtFLW2Arg4 = new System.Windows.Forms.TextBox();
-            this.txtFLW2Arg3 = new System.Windows.Forms.TextBox();
-            this.txtFLW2Arg2 = new System.Windows.Forms.TextBox();
-            this.txtFLW2Arg1 = new System.Windows.Forms.TextBox();
-            this.txtFLW2Padding = new System.Windows.Forms.TextBox();
-            this.lblFLW2Padding = new System.Windows.Forms.Label();
-            this.txtFLW2FlowType = new System.Windows.Forms.TextBox();
-            this.lblFLW2FlowType = new System.Windows.Forms.Label();
-            this.tbpDebugMSBF = new System.Windows.Forms.TabPage();
-            this.lblMSBFHashCalculator = new System.Windows.Forms.Label();
+            this.gbxListEditFen1 = new System.Windows.Forms.GroupBox();
+            this.btnDeleteFen1List = new System.Windows.Forms.Button();
+            this.btnAddFen1List = new System.Windows.Forms.Button();
+            this.txtFen1ListName = new System.Windows.Forms.TextBox();
+            this.lblFen1ListName = new System.Windows.Forms.Label();
+            this.gbxListEditFlw2 = new System.Windows.Forms.GroupBox();
+            this.btnDeleteFlw2List = new System.Windows.Forms.Button();
+            this.btnAddFlw2List = new System.Windows.Forms.Button();
+            this.lblFlw2ListEditDiscription = new System.Windows.Forms.Label();
+            this.gbxListEditMsbt = new System.Windows.Forms.GroupBox();
+            this.lblMsbtListEditDiscription = new System.Windows.Forms.Label();
+            this.lblMsbtListName = new System.Windows.Forms.Label();
+            this.txtSelectedMsbtListName = new System.Windows.Forms.TextBox();
+            this.lblMsbtListEditNote = new System.Windows.Forms.Label();
+            this.btnDeleteMsbtList = new System.Windows.Forms.Button();
+            this.txtMsbtListName = new System.Windows.Forms.TextBox();
+            this.btnAddMsbtList = new System.Windows.Forms.Button();
+            this.tbpMsbfSetting = new System.Windows.Forms.TabPage();
+            this.chkShowTvwMsbfFlow = new System.Windows.Forms.CheckBox();
+            this.btnReloadTvwMsbfFlow = new System.Windows.Forms.Button();
+            this.txtReadOnlyMsbtText = new System.Windows.Forms.TextBox();
+            this.lblMsbfFlow = new System.Windows.Forms.Label();
+            this.tvwMsbfFlow = new System.Windows.Forms.TreeView();
+            this.lblMsbfSettingNote = new System.Windows.Forms.Label();
+            this.gbxFen1 = new System.Windows.Forms.GroupBox();
+            this.lblFlw2StartIndex = new System.Windows.Forms.Label();
+            this.lblFen1Arg0 = new System.Windows.Forms.Label();
+            this.txtFen1StartIndex = new System.Windows.Forms.TextBox();
+            this.txtFen1Arg0 = new System.Windows.Forms.TextBox();
+            this.gbxFlw2 = new System.Windows.Forms.GroupBox();
+            this.lblFlw2RightAngleSymbol = new System.Windows.Forms.Label();
+            this.gbxFlw2Branch = new System.Windows.Forms.GroupBox();
+            this.txtFlw2BranchFalse = new System.Windows.Forms.TextBox();
+            this.txtFlw2BranchTrue = new System.Windows.Forms.TextBox();
+            this.lblFlw2BranchFalse = new System.Windows.Forms.Label();
+            this.lblFlw2BranchTrue = new System.Windows.Forms.Label();
+            this.lblFlw2Arg4 = new System.Windows.Forms.Label();
+            this.lblFlw2Arg3 = new System.Windows.Forms.Label();
+            this.lblFlw2Arg2 = new System.Windows.Forms.Label();
+            this.lblFlw2Arg1 = new System.Windows.Forms.Label();
+            this.txtFlw2Arg4 = new System.Windows.Forms.TextBox();
+            this.txtFlw2Arg3 = new System.Windows.Forms.TextBox();
+            this.txtFlw2Arg2 = new System.Windows.Forms.TextBox();
+            this.txtFlw2Arg1 = new System.Windows.Forms.TextBox();
+            this.txtFlw2Padding = new System.Windows.Forms.TextBox();
+            this.lblFlw2Padding = new System.Windows.Forms.Label();
+            this.txtFlw2FlowType = new System.Windows.Forms.TextBox();
+            this.lblFlw2FlowType = new System.Windows.Forms.Label();
+            this.tbpDebugMsbf = new System.Windows.Forms.TabPage();
+            this.lblMsbfHashCalculator = new System.Windows.Forms.Label();
             this.textBox34 = new System.Windows.Forms.TextBox();
             this.button30 = new System.Windows.Forms.Button();
             this.textBox33 = new System.Windows.Forms.TextBox();
@@ -194,28 +194,28 @@ namespace MSBT_Editor
             this.btnCalculateHash = new System.Windows.Forms.Button();
             this.txtListNameToCalculateHash = new System.Windows.Forms.TextBox();
             this.richTextBox1 = new System.Windows.Forms.RichTextBox();
-            this.textBox13 = new System.Windows.Forms.TextBox();
+            this.txtFlw2DebugHex = new System.Windows.Forms.TextBox();
             this.tbpDebug = new System.Windows.Forms.TabPage();
             this.textBox1 = new System.Windows.Forms.TextBox();
-            this.button1 = new System.Windows.Forms.Button();
-            this.UnknownTag = new System.Windows.Forms.TextBox();
+            this.btnTextSort = new System.Windows.Forms.Button();
+            this.txtUnknownTag = new System.Windows.Forms.TextBox();
             this.MSBT_Debug_Text = new System.Windows.Forms.TextBox();
             this.textBox27 = new System.Windows.Forms.TextBox();
             this.btnReleaseDebugTextFile = new System.Windows.Forms.Button();
             this.tbpCredit = new System.Windows.Forms.TabPage();
-            this.gbxCreditLBL1 = new System.Windows.Forms.GroupBox();
-            this.lblCreditLBL1Note = new System.Windows.Forms.Label();
-            this.lblLBL1TagIndex = new System.Windows.Forms.Label();
-            this.txtLBL1TagIndex = new System.Windows.Forms.TextBox();
-            this.txtATR1SpecialTextOffset = new System.Windows.Forms.TextBox();
+            this.gbxCreditLbl1 = new System.Windows.Forms.GroupBox();
+            this.lblCreditLbl1Note = new System.Windows.Forms.Label();
+            this.lblLbl1TagIndex = new System.Windows.Forms.Label();
+            this.txtLbl1TagIndex = new System.Windows.Forms.TextBox();
+            this.txtAtr1SpecialTextOffset = new System.Windows.Forms.TextBox();
             this.gbxCreditProgrammer = new System.Windows.Forms.GroupBox();
-            this.label54 = new System.Windows.Forms.Label();
+            this.lblCreditContributorAcknowledgment = new System.Windows.Forms.Label();
             this.gbxCreditContributor = new System.Windows.Forms.GroupBox();
             this.lblCreditEvanbowl = new System.Windows.Forms.Label();
             this.lblCreditPenguin = new System.Windows.Forms.Label();
-            this.lblATR1SpecialTextOffset = new System.Windows.Forms.Label();
+            this.lblAtr1SpecialTextOffset = new System.Windows.Forms.Label();
             this.gbxCreditDebugger = new System.Windows.Forms.GroupBox();
-            this.label55 = new System.Windows.Forms.Label();
+            this.lblDebuggerAcknowledgment = new System.Windows.Forms.Label();
             this.gbxCreditDebuggerVIP = new System.Windows.Forms.GroupBox();
             this.lblCreditXenon = new System.Windows.Forms.Label();
             this.lblCreditDossun = new System.Windows.Forms.Label();
@@ -223,70 +223,70 @@ namespace MSBT_Editor
             this.lblCreditHiiraghi = new System.Windows.Forms.Label();
             this.lblCreditEigen = new System.Windows.Forms.Label();
             this.gbxCreditSectionEntrySize = new System.Windows.Forms.GroupBox();
-            this.txtATR1EntrySize = new System.Windows.Forms.TextBox();
-            this.lblATR1EntrySize = new System.Windows.Forms.Label();
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote = new System.Windows.Forms.Label();
-            this.txtLBL1EntrySize = new System.Windows.Forms.TextBox();
-            this.lblLBL1EntrySize = new System.Windows.Forms.Label();
+            this.txtAtr1EntrySize = new System.Windows.Forms.TextBox();
+            this.lblAtr1EntrySize = new System.Windows.Forms.Label();
+            this.lblCreditSectionEntrySize = new System.Windows.Forms.Label();
+            this.txtLbl1EntrySize = new System.Windows.Forms.TextBox();
+            this.lblLbl1EntrySize = new System.Windows.Forms.Label();
             this.tbpInfomation = new System.Windows.Forms.TabPage();
             this.gbxCurrentVersion = new System.Windows.Forms.GroupBox();
             this.lblCurrentVersion = new System.Windows.Forms.Label();
-            this.lblGitHubReleasesURL = new System.Windows.Forms.Label();
+            this.lblGitHubReleasesUrl = new System.Windows.Forms.Label();
             this.gbxHowToUse = new System.Windows.Forms.GroupBox();
-            this.lblSMG2HackWikiURL = new System.Windows.Forms.Label();
-            this.llbSMG2HackWikiURL = new System.Windows.Forms.LinkLabel();
-            this.lblSMG2HackDiscordURL = new System.Windows.Forms.Label();
-            this.llbSMG2HackDiscordURL = new System.Windows.Forms.LinkLabel();
-            this.lblGitHubIssuesURL = new System.Windows.Forms.Label();
-            this.llbGitHubRepositoryURL = new System.Windows.Forms.LinkLabel();
-            this.llbGitHubReleasesURL = new System.Windows.Forms.LinkLabel();
-            this.lblGitHubRepositoryURL = new System.Windows.Forms.Label();
-            this.llbGitHubIssuesURL = new System.Windows.Forms.LinkLabel();
-            this.lstListsInsideFEN1 = new System.Windows.Forms.ListBox();
-            this.lstListsInsideFLW2 = new System.Windows.Forms.ListBox();
-            this.lblMSBT = new System.Windows.Forms.Label();
-            this.lblFLW2 = new System.Windows.Forms.Label();
-            this.lblFEN1 = new System.Windows.Forms.Label();
+            this.lblSMG2HackWikiUrl = new System.Windows.Forms.Label();
+            this.llbSMG2HackWikiUrl = new System.Windows.Forms.LinkLabel();
+            this.lblSMG2HackDiscordUrl = new System.Windows.Forms.Label();
+            this.llbSMG2HackDiscordUrl = new System.Windows.Forms.LinkLabel();
+            this.lblGitHubIssuesUrl = new System.Windows.Forms.Label();
+            this.llbGitHubRepositoryUrl = new System.Windows.Forms.LinkLabel();
+            this.llbGitHubReleasesUrl = new System.Windows.Forms.LinkLabel();
+            this.lblGitHubRepositoryUrl = new System.Windows.Forms.Label();
+            this.llbGitHubIssuesUrl = new System.Windows.Forms.LinkLabel();
+            this.lstListsInsideFen1 = new System.Windows.Forms.ListBox();
+            this.lstListsInsideFlw2 = new System.Windows.Forms.ListBox();
+            this.lblMsbt = new System.Windows.Forms.Label();
+            this.lblFlw2 = new System.Windows.Forms.Label();
+            this.lblFen1 = new System.Windows.Forms.Label();
             this.cmbLanguage = new System.Windows.Forms.ComboBox();
             this.lblLanguage = new System.Windows.Forms.Label();
-            this.lblMSBTListSelectIndex = new System.Windows.Forms.Label();
-            this.lblFLW2ListSelectIndex = new System.Windows.Forms.Label();
-            this.lblFEN1ListSelectIndex = new System.Windows.Forms.Label();
+            this.lblMsbtListSelectIndex = new System.Windows.Forms.Label();
+            this.lblFlw2ListSelectIndex = new System.Windows.Forms.Label();
+            this.lblFen1ListSelectIndex = new System.Windows.Forms.Label();
             this.tabControl3 = new System.Windows.Forms.TabControl();
-            this.tbpFilesInsideRARC = new System.Windows.Forms.TabPage();
-            this.chkMSBAutoSave = new System.Windows.Forms.CheckBox();
+            this.tbpFilesInsideRarc = new System.Windows.Forms.TabPage();
+            this.chkMsbAutoSave = new System.Windows.Forms.CheckBox();
             this.lblSaveSystemDiscription = new System.Windows.Forms.Label();
-            this.lstFilesInsideRARC = new System.Windows.Forms.ListBox();
-            this.tbpListsInsideMSB = new System.Windows.Forms.TabPage();
+            this.lstFilesInsideRarc = new System.Windows.Forms.ListBox();
+            this.tbpListsInsideMsb = new System.Windows.Forms.TabPage();
             this.stbStatusBar.SuspendLayout();
             this.menuStrip1.SuspendLayout();
             this.tabControl1.SuspendLayout();
-            this.tbpMSBTSettings.SuspendLayout();
-            this.gbxMSBTSettingsATR1.SuspendLayout();
-            this.tabPage2.SuspendLayout();
+            this.tbpMsbtSetting.SuspendLayout();
+            this.gbxMsbtSettingsAtr1.SuspendLayout();
+            this.tbpMsbtTextEdit.SuspendLayout();
             this.tabControl2.SuspendLayout();
-            this.tabPage6.SuspendLayout();
-            this.tabPage7.SuspendLayout();
+            this.tbpGeneralTag.SuspendLayout();
+            this.tbpValueTag.SuspendLayout();
             this.gbxTimerTag.SuspendLayout();
             this.gbxRubiTag.SuspendLayout();
-            this.tabPage8.SuspendLayout();
+            this.tbpSpecialTag.SuspendLayout();
             this.gbxSpecialTag.SuspendLayout();
-            this.tabPage9.SuspendLayout();
+            this.tbpIconTag.SuspendLayout();
             this.AdvancedTagsTabPage.SuspendLayout();
             this.gbxSoundEffectTag.SuspendLayout();
             this.gbxCustomIconTag.SuspendLayout();
             this.tbpListEdit.SuspendLayout();
-            this.gbxListEditFEN1.SuspendLayout();
-            this.gbxListEditFLW2.SuspendLayout();
-            this.gbxListEditMSBT.SuspendLayout();
-            this.tbpMSBFSetting.SuspendLayout();
-            this.gbxFEN1.SuspendLayout();
-            this.gbxFLW2.SuspendLayout();
-            this.gbxFLW2Branch.SuspendLayout();
-            this.tbpDebugMSBF.SuspendLayout();
+            this.gbxListEditFen1.SuspendLayout();
+            this.gbxListEditFlw2.SuspendLayout();
+            this.gbxListEditMsbt.SuspendLayout();
+            this.tbpMsbfSetting.SuspendLayout();
+            this.gbxFen1.SuspendLayout();
+            this.gbxFlw2.SuspendLayout();
+            this.gbxFlw2Branch.SuspendLayout();
+            this.tbpDebugMsbf.SuspendLayout();
             this.tbpDebug.SuspendLayout();
             this.tbpCredit.SuspendLayout();
-            this.gbxCreditLBL1.SuspendLayout();
+            this.gbxCreditLbl1.SuspendLayout();
             this.gbxCreditProgrammer.SuspendLayout();
             this.gbxCreditContributor.SuspendLayout();
             this.gbxCreditDebugger.SuspendLayout();
@@ -296,19 +296,19 @@ namespace MSBT_Editor
             this.gbxCurrentVersion.SuspendLayout();
             this.gbxHowToUse.SuspendLayout();
             this.tabControl3.SuspendLayout();
-            this.tbpFilesInsideRARC.SuspendLayout();
-            this.tbpListsInsideMSB.SuspendLayout();
+            this.tbpFilesInsideRarc.SuspendLayout();
+            this.tbpListsInsideMsb.SuspendLayout();
             this.SuspendLayout();
             // 
             // stbStatusBar
             // 
             this.stbStatusBar.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.stbStatusLabel,
-            this.stbOpenedMSBTName,
+            this.stbOpenedMsbtName,
             this.toolStripStatusLabel3,
-            this.stbOpenedMSBFName,
+            this.stbOpenedMsbfName,
             this.toolStripStatusLabel5,
-            this.stbOpenedRARCName,
+            this.stbOpenedRarcName,
             this.toolStripStatusLabel8,
             this.stbSavedFilePathLabel,
             this.stbSavedFilePath});
@@ -324,11 +324,11 @@ namespace MSBT_Editor
             this.stbStatusLabel.Size = new System.Drawing.Size(43, 17);
             this.stbStatusLabel.Text = "状態：";
             // 
-            // stbOpenedMSBTName
+            // stbOpenedMsbtName
             // 
-            this.stbOpenedMSBTName.Name = "stbOpenedMSBTName";
-            this.stbOpenedMSBTName.Size = new System.Drawing.Size(105, 17);
-            this.stbOpenedMSBTName.Text = "<MSBTファイルなし>";
+            this.stbOpenedMsbtName.Name = "stbOpenedMsbtName";
+            this.stbOpenedMsbtName.Size = new System.Drawing.Size(105, 17);
+            this.stbOpenedMsbtName.Text = "<MSBTファイルなし>";
             // 
             // toolStripStatusLabel3
             // 
@@ -336,11 +336,11 @@ namespace MSBT_Editor
             this.toolStripStatusLabel3.Size = new System.Drawing.Size(19, 17);
             this.toolStripStatusLabel3.Text = "｜";
             // 
-            // stbOpenedMSBFName
+            // stbOpenedMsbfName
             // 
-            this.stbOpenedMSBFName.Name = "stbOpenedMSBFName";
-            this.stbOpenedMSBFName.Size = new System.Drawing.Size(105, 17);
-            this.stbOpenedMSBFName.Text = "<MSBFファイルなし>";
+            this.stbOpenedMsbfName.Name = "stbOpenedMsbfName";
+            this.stbOpenedMsbfName.Size = new System.Drawing.Size(105, 17);
+            this.stbOpenedMsbfName.Text = "<MSBFファイルなし>";
             // 
             // toolStripStatusLabel5
             // 
@@ -348,12 +348,12 @@ namespace MSBT_Editor
             this.toolStripStatusLabel5.Size = new System.Drawing.Size(19, 17);
             this.toolStripStatusLabel5.Text = "｜";
             // 
-            // stbOpenedRARCName
+            // stbOpenedRarcName
             // 
-            this.stbOpenedRARCName.Name = "stbOpenedRARCName";
-            this.stbOpenedRARCName.Size = new System.Drawing.Size(104, 17);
-            this.stbOpenedRARCName.Text = "<RARCファイルなし>";
-            this.stbOpenedRARCName.Click += new System.EventHandler(this.StbOpenedRARCName_Click);
+            this.stbOpenedRarcName.Name = "stbOpenedRarcName";
+            this.stbOpenedRarcName.Size = new System.Drawing.Size(104, 17);
+            this.stbOpenedRarcName.Text = "<RARCファイルなし>";
+            this.stbOpenedRarcName.Click += new System.EventHandler(this.StbOpenedRarcName_Click);
             // 
             // toolStripStatusLabel8
             // 
@@ -492,27 +492,27 @@ namespace MSBT_Editor
             this.ARC保存ToolStripMenuItem.Text = "ARC保存";
             this.ARC保存ToolStripMenuItem.Click += new System.EventHandler(this.ARC保存ToolStripMenuItem_Click);
             // 
-            // lstListsInsideMSBT
+            // lstListsInsideMsbt
             // 
-            this.lstListsInsideMSBT.FormattingEnabled = true;
-            this.lstListsInsideMSBT.HorizontalScrollbar = true;
-            this.lstListsInsideMSBT.ItemHeight = 12;
-            this.lstListsInsideMSBT.Location = new System.Drawing.Point(6, 27);
-            this.lstListsInsideMSBT.Name = "lstListsInsideMSBT";
-            this.lstListsInsideMSBT.ScrollAlwaysVisible = true;
-            this.lstListsInsideMSBT.Size = new System.Drawing.Size(204, 424);
-            this.lstListsInsideMSBT.TabIndex = 2;
-            this.lstListsInsideMSBT.SelectedIndexChanged += new System.EventHandler(this.LstListsInsideMSBT_SelectedIndexChanged);
+            this.lstListsInsideMsbt.FormattingEnabled = true;
+            this.lstListsInsideMsbt.HorizontalScrollbar = true;
+            this.lstListsInsideMsbt.ItemHeight = 12;
+            this.lstListsInsideMsbt.Location = new System.Drawing.Point(6, 27);
+            this.lstListsInsideMsbt.Name = "lstListsInsideMsbt";
+            this.lstListsInsideMsbt.ScrollAlwaysVisible = true;
+            this.lstListsInsideMsbt.Size = new System.Drawing.Size(204, 424);
+            this.lstListsInsideMsbt.TabIndex = 2;
+            this.lstListsInsideMsbt.SelectedIndexChanged += new System.EventHandler(this.LstListsInsideMsbt_SelectedIndexChanged);
             // 
-            // txtMSBTText
+            // txtMsbtText
             // 
-            this.txtMSBTText.Location = new System.Drawing.Point(6, 6);
-            this.txtMSBTText.Multiline = true;
-            this.txtMSBTText.Name = "txtMSBTText";
-            this.txtMSBTText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtMSBTText.Size = new System.Drawing.Size(548, 256);
-            this.txtMSBTText.TabIndex = 3;
-            this.txtMSBTText.TextChanged += new System.EventHandler(this.TxtMsbtText_TextChanged);
+            this.txtMsbtText.Location = new System.Drawing.Point(6, 6);
+            this.txtMsbtText.Multiline = true;
+            this.txtMsbtText.Name = "txtMsbtText";
+            this.txtMsbtText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtMsbtText.Size = new System.Drawing.Size(548, 256);
+            this.txtMsbtText.TabIndex = 3;
+            this.txtMsbtText.TextChanged += new System.EventHandler(this.TxtMsbtText_TextChanged);
             // 
             // textBox2
             // 
@@ -525,11 +525,11 @@ namespace MSBT_Editor
             // 
             // tabControl1
             // 
-            this.tabControl1.Controls.Add(this.tbpMSBTSettings);
-            this.tabControl1.Controls.Add(this.tabPage2);
+            this.tabControl1.Controls.Add(this.tbpMsbtSetting);
+            this.tabControl1.Controls.Add(this.tbpMsbtTextEdit);
             this.tabControl1.Controls.Add(this.tbpListEdit);
-            this.tabControl1.Controls.Add(this.tbpMSBFSetting);
-            this.tabControl1.Controls.Add(this.tbpDebugMSBF);
+            this.tabControl1.Controls.Add(this.tbpMsbfSetting);
+            this.tabControl1.Controls.Add(this.tbpDebugMsbf);
             this.tabControl1.Controls.Add(this.tbpDebug);
             this.tabControl1.Controls.Add(this.tbpCredit);
             this.tabControl1.Controls.Add(this.tbpInfomation);
@@ -539,211 +539,211 @@ namespace MSBT_Editor
             this.tabControl1.Size = new System.Drawing.Size(568, 460);
             this.tabControl1.TabIndex = 5;
             // 
-            // tbpMSBTSettings
+            // tbpMsbtSetting
             // 
-            this.tbpMSBTSettings.Controls.Add(this.gbxMSBTSettingsATR1);
-            this.tbpMSBTSettings.Location = new System.Drawing.Point(4, 22);
-            this.tbpMSBTSettings.Name = "tbpMSBTSettings";
-            this.tbpMSBTSettings.Padding = new System.Windows.Forms.Padding(3);
-            this.tbpMSBTSettings.Size = new System.Drawing.Size(560, 434);
-            this.tbpMSBTSettings.TabIndex = 0;
-            this.tbpMSBTSettings.Text = "MSBTテキストの詳細設定";
-            this.tbpMSBTSettings.UseVisualStyleBackColor = true;
+            this.tbpMsbtSetting.Controls.Add(this.gbxMsbtSettingsAtr1);
+            this.tbpMsbtSetting.Location = new System.Drawing.Point(4, 22);
+            this.tbpMsbtSetting.Name = "tbpMsbtSetting";
+            this.tbpMsbtSetting.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpMsbtSetting.Size = new System.Drawing.Size(560, 434);
+            this.tbpMsbtSetting.TabIndex = 0;
+            this.tbpMsbtSetting.Text = "MSBTテキストの詳細設定";
+            this.tbpMsbtSetting.UseVisualStyleBackColor = true;
             // 
-            // gbxMSBTSettingsATR1
+            // gbxMsbtSettingsAtr1
             // 
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1SpecialText);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1SpecialText);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1Unknown6);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1MessageAreaID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1EventCameraID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1WindowID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1DialogID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1SimpleCamID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.lblATR1SoundID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1Unknown6);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1MessageAreaID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1EventCameraID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1WindowID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1DialogID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1SimpleCamID);
-            this.gbxMSBTSettingsATR1.Controls.Add(this.txtATR1SoundID);
-            this.gbxMSBTSettingsATR1.Location = new System.Drawing.Point(6, 6);
-            this.gbxMSBTSettingsATR1.Name = "gbxMSBTSettingsATR1";
-            this.gbxMSBTSettingsATR1.Size = new System.Drawing.Size(548, 290);
-            this.gbxMSBTSettingsATR1.TabIndex = 4;
-            this.gbxMSBTSettingsATR1.TabStop = false;
-            this.gbxMSBTSettingsATR1.Text = "選択されたMSBTメッセージの詳細設定";
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1SpecialText);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1SpecialText);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1Unknown6);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1MessageAreaID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1EventCameraID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1WindowID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1DialogID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1SimpleCamID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1SoundID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1Unknown6);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1MessageAreaID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1EventCameraID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1WindowID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1DialogID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1SimpleCamID);
+            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1SoundID);
+            this.gbxMsbtSettingsAtr1.Location = new System.Drawing.Point(6, 6);
+            this.gbxMsbtSettingsAtr1.Name = "gbxMsbtSettingsAtr1";
+            this.gbxMsbtSettingsAtr1.Size = new System.Drawing.Size(548, 290);
+            this.gbxMsbtSettingsAtr1.TabIndex = 4;
+            this.gbxMsbtSettingsAtr1.TabStop = false;
+            this.gbxMsbtSettingsAtr1.Text = "選択されたMSBTメッセージの詳細設定";
             // 
-            // lblATR1SpecialText
+            // lblAtr1SpecialText
             // 
-            this.lblATR1SpecialText.AutoSize = true;
-            this.lblATR1SpecialText.Location = new System.Drawing.Point(6, 197);
-            this.lblATR1SpecialText.Name = "lblATR1SpecialText";
-            this.lblATR1SpecialText.Size = new System.Drawing.Size(231, 12);
-            this.lblATR1SpecialText.TabIndex = 17;
-            this.lblATR1SpecialText.Text = "特殊テキスト(基本null) ※上級者以外触らない";
+            this.lblAtr1SpecialText.AutoSize = true;
+            this.lblAtr1SpecialText.Location = new System.Drawing.Point(6, 197);
+            this.lblAtr1SpecialText.Name = "lblAtr1SpecialText";
+            this.lblAtr1SpecialText.Size = new System.Drawing.Size(231, 12);
+            this.lblAtr1SpecialText.TabIndex = 17;
+            this.lblAtr1SpecialText.Text = "特殊テキスト(基本null) ※上級者以外触らない";
             // 
-            // txtATR1SpecialText
+            // txtAtr1SpecialText
             // 
-            this.txtATR1SpecialText.Location = new System.Drawing.Point(8, 212);
-            this.txtATR1SpecialText.Multiline = true;
-            this.txtATR1SpecialText.Name = "txtATR1SpecialText";
-            this.txtATR1SpecialText.Size = new System.Drawing.Size(536, 68);
-            this.txtATR1SpecialText.TabIndex = 16;
-            this.txtATR1SpecialText.TextChanged += new System.EventHandler(this.TxtATR1SpecialText_TextChanged);
-            this.txtATR1SpecialText.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1SpecialText_KeyPress);
+            this.txtAtr1SpecialText.Location = new System.Drawing.Point(8, 212);
+            this.txtAtr1SpecialText.Multiline = true;
+            this.txtAtr1SpecialText.Name = "txtAtr1SpecialText";
+            this.txtAtr1SpecialText.Size = new System.Drawing.Size(536, 68);
+            this.txtAtr1SpecialText.TabIndex = 16;
+            this.txtAtr1SpecialText.TextChanged += new System.EventHandler(this.TxtAtr1SpecialText_TextChanged);
+            this.txtAtr1SpecialText.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1SpecialText_KeyPress);
             // 
-            // lblATR1Unknown6
+            // lblAtr1Unknown6
             // 
-            this.lblATR1Unknown6.AutoSize = true;
-            this.lblATR1Unknown6.Location = new System.Drawing.Point(6, 175);
-            this.lblATR1Unknown6.Name = "lblATR1Unknown6";
-            this.lblATR1Unknown6.Size = new System.Drawing.Size(61, 12);
-            this.lblATR1Unknown6.TabIndex = 14;
-            this.lblATR1Unknown6.Text = "分からない6";
+            this.lblAtr1Unknown6.AutoSize = true;
+            this.lblAtr1Unknown6.Location = new System.Drawing.Point(6, 175);
+            this.lblAtr1Unknown6.Name = "lblAtr1Unknown6";
+            this.lblAtr1Unknown6.Size = new System.Drawing.Size(61, 12);
+            this.lblAtr1Unknown6.TabIndex = 14;
+            this.lblAtr1Unknown6.Text = "分からない6";
             // 
-            // lblATR1MessageAreaID
+            // lblAtr1MessageAreaID
             // 
-            this.lblATR1MessageAreaID.AutoSize = true;
-            this.lblATR1MessageAreaID.Location = new System.Drawing.Point(6, 149);
-            this.lblATR1MessageAreaID.Name = "lblATR1MessageAreaID";
-            this.lblATR1MessageAreaID.Size = new System.Drawing.Size(100, 12);
-            this.lblATR1MessageAreaID.TabIndex = 13;
-            this.lblATR1MessageAreaID.Text = "会話制御エリアarg0";
+            this.lblAtr1MessageAreaID.AutoSize = true;
+            this.lblAtr1MessageAreaID.Location = new System.Drawing.Point(6, 149);
+            this.lblAtr1MessageAreaID.Name = "lblAtr1MessageAreaID";
+            this.lblAtr1MessageAreaID.Size = new System.Drawing.Size(100, 12);
+            this.lblAtr1MessageAreaID.TabIndex = 13;
+            this.lblAtr1MessageAreaID.Text = "会話制御エリアarg0";
             // 
-            // lblATR1EventCameraID
+            // lblAtr1EventCameraID
             // 
-            this.lblATR1EventCameraID.AutoSize = true;
-            this.lblATR1EventCameraID.Location = new System.Drawing.Point(6, 122);
-            this.lblATR1EventCameraID.Name = "lblATR1EventCameraID";
-            this.lblATR1EventCameraID.Size = new System.Drawing.Size(77, 12);
-            this.lblATR1EventCameraID.TabIndex = 12;
-            this.lblATR1EventCameraID.Text = "イベントカメラID";
+            this.lblAtr1EventCameraID.AutoSize = true;
+            this.lblAtr1EventCameraID.Location = new System.Drawing.Point(6, 122);
+            this.lblAtr1EventCameraID.Name = "lblAtr1EventCameraID";
+            this.lblAtr1EventCameraID.Size = new System.Drawing.Size(77, 12);
+            this.lblAtr1EventCameraID.TabIndex = 12;
+            this.lblAtr1EventCameraID.Text = "イベントカメラID";
             // 
-            // lblATR1WindowID
+            // lblAtr1WindowID
             // 
-            this.lblATR1WindowID.AutoSize = true;
-            this.lblATR1WindowID.Location = new System.Drawing.Point(6, 96);
-            this.lblATR1WindowID.Name = "lblATR1WindowID";
-            this.lblATR1WindowID.Size = new System.Drawing.Size(74, 12);
-            this.lblATR1WindowID.TabIndex = 11;
-            this.lblATR1WindowID.Text = "ウィンドウタイプ";
+            this.lblAtr1WindowID.AutoSize = true;
+            this.lblAtr1WindowID.Location = new System.Drawing.Point(6, 96);
+            this.lblAtr1WindowID.Name = "lblAtr1WindowID";
+            this.lblAtr1WindowID.Size = new System.Drawing.Size(74, 12);
+            this.lblAtr1WindowID.TabIndex = 11;
+            this.lblAtr1WindowID.Text = "ウィンドウタイプ";
             // 
-            // lblATR1DialogID
+            // lblAtr1DialogID
             // 
-            this.lblATR1DialogID.AutoSize = true;
-            this.lblATR1DialogID.Location = new System.Drawing.Point(6, 71);
-            this.lblATR1DialogID.Name = "lblATR1DialogID";
-            this.lblATR1DialogID.Size = new System.Drawing.Size(76, 12);
-            this.lblATR1DialogID.TabIndex = 10;
-            this.lblATR1DialogID.Text = "ダイアログタイプ";
+            this.lblAtr1DialogID.AutoSize = true;
+            this.lblAtr1DialogID.Location = new System.Drawing.Point(6, 71);
+            this.lblAtr1DialogID.Name = "lblAtr1DialogID";
+            this.lblAtr1DialogID.Size = new System.Drawing.Size(76, 12);
+            this.lblAtr1DialogID.TabIndex = 10;
+            this.lblAtr1DialogID.Text = "ダイアログタイプ";
             // 
-            // lblATR1SimpleCamID
+            // lblAtr1SimpleCamID
             // 
-            this.lblATR1SimpleCamID.AutoSize = true;
-            this.lblATR1SimpleCamID.Location = new System.Drawing.Point(6, 46);
-            this.lblATR1SimpleCamID.Name = "lblATR1SimpleCamID";
-            this.lblATR1SimpleCamID.Size = new System.Drawing.Size(30, 12);
-            this.lblATR1SimpleCamID.TabIndex = 9;
-            this.lblATR1SimpleCamID.Text = "カメラ";
+            this.lblAtr1SimpleCamID.AutoSize = true;
+            this.lblAtr1SimpleCamID.Location = new System.Drawing.Point(6, 46);
+            this.lblAtr1SimpleCamID.Name = "lblAtr1SimpleCamID";
+            this.lblAtr1SimpleCamID.Size = new System.Drawing.Size(30, 12);
+            this.lblAtr1SimpleCamID.TabIndex = 9;
+            this.lblAtr1SimpleCamID.Text = "カメラ";
             // 
-            // lblATR1SoundID
+            // lblAtr1SoundID
             // 
-            this.lblATR1SoundID.AutoSize = true;
-            this.lblATR1SoundID.Location = new System.Drawing.Point(6, 21);
-            this.lblATR1SoundID.Name = "lblATR1SoundID";
-            this.lblATR1SoundID.Size = new System.Drawing.Size(42, 12);
-            this.lblATR1SoundID.TabIndex = 8;
-            this.lblATR1SoundID.Text = "サウンド";
+            this.lblAtr1SoundID.AutoSize = true;
+            this.lblAtr1SoundID.Location = new System.Drawing.Point(6, 21);
+            this.lblAtr1SoundID.Name = "lblAtr1SoundID";
+            this.lblAtr1SoundID.Size = new System.Drawing.Size(42, 12);
+            this.lblAtr1SoundID.TabIndex = 8;
+            this.lblAtr1SoundID.Text = "サウンド";
             // 
-            // txtATR1Unknown6
+            // txtAtr1Unknown6
             // 
-            this.txtATR1Unknown6.Location = new System.Drawing.Point(147, 172);
-            this.txtATR1Unknown6.MaxLength = 2;
-            this.txtATR1Unknown6.Name = "txtATR1Unknown6";
-            this.txtATR1Unknown6.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1Unknown6.TabIndex = 6;
-            this.txtATR1Unknown6.TextChanged += new System.EventHandler(this.TxtATR1Unknown6_TextChanged);
-            this.txtATR1Unknown6.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1Unknown6_KeyPress);
+            this.txtAtr1Unknown6.Location = new System.Drawing.Point(147, 172);
+            this.txtAtr1Unknown6.MaxLength = 2;
+            this.txtAtr1Unknown6.Name = "txtAtr1Unknown6";
+            this.txtAtr1Unknown6.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1Unknown6.TabIndex = 6;
+            this.txtAtr1Unknown6.TextChanged += new System.EventHandler(this.TxtAtr1Unknown6_TextChanged);
+            this.txtAtr1Unknown6.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1Unknown6_KeyPress);
             // 
-            // txtATR1MessageAreaID
+            // txtAtr1MessageAreaID
             // 
-            this.txtATR1MessageAreaID.Location = new System.Drawing.Point(147, 146);
-            this.txtATR1MessageAreaID.Name = "txtATR1MessageAreaID";
-            this.txtATR1MessageAreaID.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1MessageAreaID.TabIndex = 5;
-            this.txtATR1MessageAreaID.TextChanged += new System.EventHandler(this.TxtATR1MessageAreaID_TextChanged);
-            this.txtATR1MessageAreaID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1MessageAreaID_KeyPress);
+            this.txtAtr1MessageAreaID.Location = new System.Drawing.Point(147, 146);
+            this.txtAtr1MessageAreaID.Name = "txtAtr1MessageAreaID";
+            this.txtAtr1MessageAreaID.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1MessageAreaID.TabIndex = 5;
+            this.txtAtr1MessageAreaID.TextChanged += new System.EventHandler(this.TxtAtr1MessageAreaID_TextChanged);
+            this.txtAtr1MessageAreaID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1MessageAreaID_KeyPress);
             // 
-            // txtATR1EventCameraID
+            // txtAtr1EventCameraID
             // 
-            this.txtATR1EventCameraID.Location = new System.Drawing.Point(147, 119);
-            this.txtATR1EventCameraID.MaxLength = 4;
-            this.txtATR1EventCameraID.Name = "txtATR1EventCameraID";
-            this.txtATR1EventCameraID.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1EventCameraID.TabIndex = 4;
-            this.txtATR1EventCameraID.TextChanged += new System.EventHandler(this.TxtATR1EventCameraID_TextChanged);
-            this.txtATR1EventCameraID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1EventCameraID_KeyPress);
+            this.txtAtr1EventCameraID.Location = new System.Drawing.Point(147, 119);
+            this.txtAtr1EventCameraID.MaxLength = 4;
+            this.txtAtr1EventCameraID.Name = "txtAtr1EventCameraID";
+            this.txtAtr1EventCameraID.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1EventCameraID.TabIndex = 4;
+            this.txtAtr1EventCameraID.TextChanged += new System.EventHandler(this.TxtAtr1EventCameraID_TextChanged);
+            this.txtAtr1EventCameraID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1EventCameraID_KeyPress);
             // 
-            // txtATR1WindowID
+            // txtAtr1WindowID
             // 
-            this.txtATR1WindowID.Location = new System.Drawing.Point(147, 93);
-            this.txtATR1WindowID.MaxLength = 2;
-            this.txtATR1WindowID.Name = "txtATR1WindowID";
-            this.txtATR1WindowID.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1WindowID.TabIndex = 3;
-            this.txtATR1WindowID.TextChanged += new System.EventHandler(this.TxtATR1WindowID_TextChanged);
-            this.txtATR1WindowID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1WindowID_KeyPress);
+            this.txtAtr1WindowID.Location = new System.Drawing.Point(147, 93);
+            this.txtAtr1WindowID.MaxLength = 2;
+            this.txtAtr1WindowID.Name = "txtAtr1WindowID";
+            this.txtAtr1WindowID.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1WindowID.TabIndex = 3;
+            this.txtAtr1WindowID.TextChanged += new System.EventHandler(this.TxtAtr1WindowID_TextChanged);
+            this.txtAtr1WindowID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1WindowID_KeyPress);
             // 
-            // txtATR1DialogID
+            // txtAtr1DialogID
             // 
-            this.txtATR1DialogID.Location = new System.Drawing.Point(147, 68);
-            this.txtATR1DialogID.MaxLength = 2;
-            this.txtATR1DialogID.Name = "txtATR1DialogID";
-            this.txtATR1DialogID.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1DialogID.TabIndex = 2;
-            this.txtATR1DialogID.TextChanged += new System.EventHandler(this.TxtATR1DialogID_TextChanged);
-            this.txtATR1DialogID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1DialogID_KeyPress);
+            this.txtAtr1DialogID.Location = new System.Drawing.Point(147, 68);
+            this.txtAtr1DialogID.MaxLength = 2;
+            this.txtAtr1DialogID.Name = "txtAtr1DialogID";
+            this.txtAtr1DialogID.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1DialogID.TabIndex = 2;
+            this.txtAtr1DialogID.TextChanged += new System.EventHandler(this.TxtAtr1DialogID_TextChanged);
+            this.txtAtr1DialogID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1DialogID_KeyPress);
             // 
-            // txtATR1SimpleCamID
+            // txtAtr1SimpleCamID
             // 
-            this.txtATR1SimpleCamID.Location = new System.Drawing.Point(147, 43);
-            this.txtATR1SimpleCamID.MaxLength = 2;
-            this.txtATR1SimpleCamID.Name = "txtATR1SimpleCamID";
-            this.txtATR1SimpleCamID.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1SimpleCamID.TabIndex = 1;
-            this.txtATR1SimpleCamID.TextChanged += new System.EventHandler(this.TxtATR1SimpleCamID_TextChanged);
-            this.txtATR1SimpleCamID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1SimpleCamID_KeyPress);
+            this.txtAtr1SimpleCamID.Location = new System.Drawing.Point(147, 43);
+            this.txtAtr1SimpleCamID.MaxLength = 2;
+            this.txtAtr1SimpleCamID.Name = "txtAtr1SimpleCamID";
+            this.txtAtr1SimpleCamID.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1SimpleCamID.TabIndex = 1;
+            this.txtAtr1SimpleCamID.TextChanged += new System.EventHandler(this.TxtAtr1SimpleCamID_TextChanged);
+            this.txtAtr1SimpleCamID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1SimpleCamID_KeyPress);
             // 
-            // txtATR1SoundID
+            // txtAtr1SoundID
             // 
-            this.txtATR1SoundID.Location = new System.Drawing.Point(147, 18);
-            this.txtATR1SoundID.MaxLength = 2;
-            this.txtATR1SoundID.Name = "txtATR1SoundID";
-            this.txtATR1SoundID.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1SoundID.TabIndex = 0;
-            this.txtATR1SoundID.TextChanged += new System.EventHandler(this.TxtATR1SoundID_TextChanged);
-            this.txtATR1SoundID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtATR1SoundID_KeyPress);
+            this.txtAtr1SoundID.Location = new System.Drawing.Point(147, 18);
+            this.txtAtr1SoundID.MaxLength = 2;
+            this.txtAtr1SoundID.Name = "txtAtr1SoundID";
+            this.txtAtr1SoundID.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1SoundID.TabIndex = 0;
+            this.txtAtr1SoundID.TextChanged += new System.EventHandler(this.TxtATR1SoundID_TextChanged);
+            this.txtAtr1SoundID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1SoundID_KeyPress);
             // 
-            // tabPage2
+            // tbpMsbtTextEdit
             // 
-            this.tabPage2.Controls.Add(this.tabControl2);
-            this.tabPage2.Controls.Add(this.txtMSBTText);
-            this.tabPage2.Location = new System.Drawing.Point(4, 22);
-            this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(560, 434);
-            this.tabPage2.TabIndex = 1;
-            this.tabPage2.Text = "MSBTテキスト編集";
-            this.tabPage2.UseVisualStyleBackColor = true;
+            this.tbpMsbtTextEdit.Controls.Add(this.tabControl2);
+            this.tbpMsbtTextEdit.Controls.Add(this.txtMsbtText);
+            this.tbpMsbtTextEdit.Location = new System.Drawing.Point(4, 22);
+            this.tbpMsbtTextEdit.Name = "tbpMsbtTextEdit";
+            this.tbpMsbtTextEdit.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpMsbtTextEdit.Size = new System.Drawing.Size(560, 434);
+            this.tbpMsbtTextEdit.TabIndex = 1;
+            this.tbpMsbtTextEdit.Text = "MSBTテキスト編集";
+            this.tbpMsbtTextEdit.UseVisualStyleBackColor = true;
             // 
             // tabControl2
             // 
-            this.tabControl2.Controls.Add(this.tabPage6);
-            this.tabControl2.Controls.Add(this.tabPage7);
-            this.tabControl2.Controls.Add(this.tabPage8);
-            this.tabControl2.Controls.Add(this.tabPage9);
+            this.tabControl2.Controls.Add(this.tbpGeneralTag);
+            this.tabControl2.Controls.Add(this.tbpValueTag);
+            this.tabControl2.Controls.Add(this.tbpSpecialTag);
+            this.tabControl2.Controls.Add(this.tbpIconTag);
             this.tabControl2.Controls.Add(this.AdvancedTagsTabPage);
             this.tabControl2.Location = new System.Drawing.Point(6, 268);
             this.tabControl2.Name = "tabControl2";
@@ -751,24 +751,24 @@ namespace MSBT_Editor
             this.tabControl2.Size = new System.Drawing.Size(548, 167);
             this.tabControl2.TabIndex = 12;
             // 
-            // tabPage6
+            // tbpGeneralTag
             // 
-            this.tabPage6.Controls.Add(this.btnInsertColorTag);
-            this.tabPage6.Controls.Add(this.btnInsertPlayerCharacterTag);
-            this.tabPage6.Controls.Add(this.cmbCenterTag);
-            this.tabPage6.Controls.Add(this.btnInsertCenterTag);
-            this.tabPage6.Controls.Add(this.cmbColorTag);
-            this.tabPage6.Controls.Add(this.btnInsertLineControlTag);
-            this.tabPage6.Controls.Add(this.cmbFontSizeTag);
-            this.tabPage6.Controls.Add(this.btnInsertFontSizeTag);
-            this.tabPage6.Controls.Add(this.cmbLineControlTag);
-            this.tabPage6.Location = new System.Drawing.Point(4, 22);
-            this.tabPage6.Name = "tabPage6";
-            this.tabPage6.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage6.Size = new System.Drawing.Size(540, 141);
-            this.tabPage6.TabIndex = 0;
-            this.tabPage6.Text = "汎用タグ";
-            this.tabPage6.UseVisualStyleBackColor = true;
+            this.tbpGeneralTag.Controls.Add(this.btnInsertColorTag);
+            this.tbpGeneralTag.Controls.Add(this.btnInsertPlayerCharacterTag);
+            this.tbpGeneralTag.Controls.Add(this.cmbCenterTag);
+            this.tbpGeneralTag.Controls.Add(this.btnInsertCenterTag);
+            this.tbpGeneralTag.Controls.Add(this.cmbColorTag);
+            this.tbpGeneralTag.Controls.Add(this.btnInsertLineControlTag);
+            this.tbpGeneralTag.Controls.Add(this.cmbFontSizeTag);
+            this.tbpGeneralTag.Controls.Add(this.btnInsertFontSizeTag);
+            this.tbpGeneralTag.Controls.Add(this.cmbLineControlTag);
+            this.tbpGeneralTag.Location = new System.Drawing.Point(4, 22);
+            this.tbpGeneralTag.Name = "tbpGeneralTag";
+            this.tbpGeneralTag.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpGeneralTag.Size = new System.Drawing.Size(540, 141);
+            this.tbpGeneralTag.TabIndex = 0;
+            this.tbpGeneralTag.Text = "汎用タグ";
+            this.tbpGeneralTag.UseVisualStyleBackColor = true;
             // 
             // btnInsertColorTag
             // 
@@ -877,17 +877,17 @@ namespace MSBT_Editor
             this.cmbLineControlTag.TabIndex = 6;
             this.cmbLineControlTag.Text = "改行";
             // 
-            // tabPage7
+            // tbpValueTag
             // 
-            this.tabPage7.Controls.Add(this.gbxTimerTag);
-            this.tabPage7.Controls.Add(this.gbxRubiTag);
-            this.tabPage7.Location = new System.Drawing.Point(4, 22);
-            this.tabPage7.Name = "tabPage7";
-            this.tabPage7.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage7.Size = new System.Drawing.Size(540, 141);
-            this.tabPage7.TabIndex = 1;
-            this.tabPage7.Text = "数値必要タグ";
-            this.tabPage7.UseVisualStyleBackColor = true;
+            this.tbpValueTag.Controls.Add(this.gbxTimerTag);
+            this.tbpValueTag.Controls.Add(this.gbxRubiTag);
+            this.tbpValueTag.Location = new System.Drawing.Point(4, 22);
+            this.tbpValueTag.Name = "tbpValueTag";
+            this.tbpValueTag.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpValueTag.Size = new System.Drawing.Size(540, 141);
+            this.tbpValueTag.TabIndex = 1;
+            this.tbpValueTag.Text = "数値必要タグ";
+            this.tbpValueTag.UseVisualStyleBackColor = true;
             // 
             // gbxTimerTag
             // 
@@ -996,16 +996,16 @@ namespace MSBT_Editor
             this.txtRubiTagKanjiCount.TabIndex = 1;
             this.txtRubiTagKanjiCount.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtRubiTagKanjiCount_KeyPress);
             // 
-            // tabPage8
+            // tbpSpecialTag
             // 
-            this.tabPage8.Controls.Add(this.gbxSpecialTag);
-            this.tabPage8.Location = new System.Drawing.Point(4, 22);
-            this.tabPage8.Name = "tabPage8";
-            this.tabPage8.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage8.Size = new System.Drawing.Size(540, 141);
-            this.tabPage8.TabIndex = 2;
-            this.tabPage8.Text = "特殊タグ";
-            this.tabPage8.UseVisualStyleBackColor = true;
+            this.tbpSpecialTag.Controls.Add(this.gbxSpecialTag);
+            this.tbpSpecialTag.Location = new System.Drawing.Point(4, 22);
+            this.tbpSpecialTag.Name = "tbpSpecialTag";
+            this.tbpSpecialTag.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpSpecialTag.Size = new System.Drawing.Size(540, 141);
+            this.tbpSpecialTag.TabIndex = 2;
+            this.tbpSpecialTag.Text = "特殊タグ";
+            this.tbpSpecialTag.UseVisualStyleBackColor = true;
             // 
             // gbxSpecialTag
             // 
@@ -1159,24 +1159,24 @@ namespace MSBT_Editor
             this.btnInsertResultGalaxyNameTag.UseVisualStyleBackColor = true;
             this.btnInsertResultGalaxyNameTag.Click += new System.EventHandler(this.BtnInsertResultGalaxyNameTag_Click);
             // 
-            // tabPage9
+            // tbpIconTag
             // 
-            this.tabPage9.Controls.Add(this.btnInsertOthersIconTag);
-            this.tabPage9.Controls.Add(this.cmbOthersIconTag);
-            this.tabPage9.Controls.Add(this.lblOthersIconTag);
-            this.tabPage9.Controls.Add(this.lblObjectIconTag);
-            this.tabPage9.Controls.Add(this.btnInsertObjectIconTag);
-            this.tabPage9.Controls.Add(this.cmbObjectIconTag);
-            this.tabPage9.Controls.Add(this.lblCharacterIconTag);
-            this.tabPage9.Controls.Add(this.btnInsertCharacterIconTag);
-            this.tabPage9.Controls.Add(this.cmbCharacterIconTag);
-            this.tabPage9.Location = new System.Drawing.Point(4, 22);
-            this.tabPage9.Name = "tabPage9";
-            this.tabPage9.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage9.Size = new System.Drawing.Size(540, 141);
-            this.tabPage9.TabIndex = 3;
-            this.tabPage9.Text = "アイコンタグ";
-            this.tabPage9.UseVisualStyleBackColor = true;
+            this.tbpIconTag.Controls.Add(this.btnInsertOthersIconTag);
+            this.tbpIconTag.Controls.Add(this.cmbOthersIconTag);
+            this.tbpIconTag.Controls.Add(this.lblOthersIconTag);
+            this.tbpIconTag.Controls.Add(this.lblObjectIconTag);
+            this.tbpIconTag.Controls.Add(this.btnInsertObjectIconTag);
+            this.tbpIconTag.Controls.Add(this.cmbObjectIconTag);
+            this.tbpIconTag.Controls.Add(this.lblCharacterIconTag);
+            this.tbpIconTag.Controls.Add(this.btnInsertCharacterIconTag);
+            this.tbpIconTag.Controls.Add(this.cmbCharacterIconTag);
+            this.tbpIconTag.Location = new System.Drawing.Point(4, 22);
+            this.tbpIconTag.Name = "tbpIconTag";
+            this.tbpIconTag.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpIconTag.Size = new System.Drawing.Size(540, 141);
+            this.tbpIconTag.TabIndex = 3;
+            this.tbpIconTag.Text = "アイコンタグ";
+            this.tbpIconTag.UseVisualStyleBackColor = true;
             // 
             // btnInsertOthersIconTag
             // 
@@ -1376,9 +1376,9 @@ namespace MSBT_Editor
             // 
             // tbpListEdit
             // 
-            this.tbpListEdit.Controls.Add(this.gbxListEditFEN1);
-            this.tbpListEdit.Controls.Add(this.gbxListEditFLW2);
-            this.tbpListEdit.Controls.Add(this.gbxListEditMSBT);
+            this.tbpListEdit.Controls.Add(this.gbxListEditFen1);
+            this.tbpListEdit.Controls.Add(this.gbxListEditFlw2);
+            this.tbpListEdit.Controls.Add(this.gbxListEditMsbt);
             this.tbpListEdit.Location = new System.Drawing.Point(4, 22);
             this.tbpListEdit.Name = "tbpListEdit";
             this.tbpListEdit.Padding = new System.Windows.Forms.Padding(3);
@@ -1387,528 +1387,528 @@ namespace MSBT_Editor
             this.tbpListEdit.Text = "リスト編集";
             this.tbpListEdit.UseVisualStyleBackColor = true;
             // 
-            // gbxListEditFEN1
-            // 
-            this.gbxListEditFEN1.Controls.Add(this.btnDeleteFEN1List);
-            this.gbxListEditFEN1.Controls.Add(this.btnAddFEN1List);
-            this.gbxListEditFEN1.Controls.Add(this.txtFEN1ListName);
-            this.gbxListEditFEN1.Controls.Add(this.lblFEN1ListName);
-            this.gbxListEditFEN1.Location = new System.Drawing.Point(3, 270);
-            this.gbxListEditFEN1.Name = "gbxListEditFEN1";
-            this.gbxListEditFEN1.Size = new System.Drawing.Size(224, 119);
-            this.gbxListEditFEN1.TabIndex = 6;
-            this.gbxListEditFEN1.TabStop = false;
-            this.gbxListEditFEN1.Text = "FEN1";
-            // 
-            // btnDeleteFEN1List
-            // 
-            this.btnDeleteFEN1List.Location = new System.Drawing.Point(137, 90);
-            this.btnDeleteFEN1List.Name = "btnDeleteFEN1List";
-            this.btnDeleteFEN1List.Size = new System.Drawing.Size(75, 23);
-            this.btnDeleteFEN1List.TabIndex = 3;
-            this.btnDeleteFEN1List.Text = "削除";
-            this.btnDeleteFEN1List.UseVisualStyleBackColor = true;
-            this.btnDeleteFEN1List.Click += new System.EventHandler(this.BtnDeleteFEN1List_Click);
-            // 
-            // btnAddFEN1List
-            // 
-            this.btnAddFEN1List.Location = new System.Drawing.Point(8, 90);
-            this.btnAddFEN1List.Name = "btnAddFEN1List";
-            this.btnAddFEN1List.Size = new System.Drawing.Size(75, 23);
-            this.btnAddFEN1List.TabIndex = 2;
-            this.btnAddFEN1List.Text = "追加";
-            this.btnAddFEN1List.UseVisualStyleBackColor = true;
-            this.btnAddFEN1List.Click += new System.EventHandler(this.BtnAddFEN1List_Click);
-            // 
-            // txtFEN1ListName
-            // 
-            this.txtFEN1ListName.Location = new System.Drawing.Point(8, 51);
-            this.txtFEN1ListName.Name = "txtFEN1ListName";
-            this.txtFEN1ListName.Size = new System.Drawing.Size(204, 19);
-            this.txtFEN1ListName.TabIndex = 1;
-            this.txtFEN1ListName.TextChanged += new System.EventHandler(this.TxtFEN1ListName_TextChanged);
-            // 
-            // lblFEN1ListName
-            // 
-            this.lblFEN1ListName.AutoSize = true;
-            this.lblFEN1ListName.Location = new System.Drawing.Point(6, 19);
-            this.lblFEN1ListName.Name = "lblFEN1ListName";
-            this.lblFEN1ListName.Size = new System.Drawing.Size(168, 12);
-            this.lblFEN1ListName.TabIndex = 0;
-            this.lblFEN1ListName.Text = "名前必須(Flowなどを省いた名前)";
-            // 
-            // gbxListEditFLW2
-            // 
-            this.gbxListEditFLW2.Controls.Add(this.btnDeleteFLW2List);
-            this.gbxListEditFLW2.Controls.Add(this.btnAddFLW2List);
-            this.gbxListEditFLW2.Controls.Add(this.lblFLW2ListEditDiscription);
-            this.gbxListEditFLW2.Location = new System.Drawing.Point(3, 164);
-            this.gbxListEditFLW2.Name = "gbxListEditFLW2";
-            this.gbxListEditFLW2.Size = new System.Drawing.Size(224, 100);
-            this.gbxListEditFLW2.TabIndex = 5;
-            this.gbxListEditFLW2.TabStop = false;
-            this.gbxListEditFLW2.Text = "FLW2";
-            // 
-            // btnDeleteFLW2List
-            // 
-            this.btnDeleteFLW2List.Location = new System.Drawing.Point(137, 58);
-            this.btnDeleteFLW2List.Name = "btnDeleteFLW2List";
-            this.btnDeleteFLW2List.Size = new System.Drawing.Size(75, 23);
-            this.btnDeleteFLW2List.TabIndex = 3;
-            this.btnDeleteFLW2List.Text = "削除";
-            this.btnDeleteFLW2List.UseVisualStyleBackColor = true;
-            this.btnDeleteFLW2List.Click += new System.EventHandler(this.BtnDeleteFLW2List_Click);
-            // 
-            // btnAddFLW2List
-            // 
-            this.btnAddFLW2List.Location = new System.Drawing.Point(8, 58);
-            this.btnAddFLW2List.Name = "btnAddFLW2List";
-            this.btnAddFLW2List.Size = new System.Drawing.Size(75, 23);
-            this.btnAddFLW2List.TabIndex = 2;
-            this.btnAddFLW2List.Text = "追加";
-            this.btnAddFLW2List.UseVisualStyleBackColor = true;
-            this.btnAddFLW2List.Click += new System.EventHandler(this.BtnAddFLW2List_Click);
-            // 
-            // lblFLW2ListEditDiscription
-            // 
-            this.lblFLW2ListEditDiscription.AutoSize = true;
-            this.lblFLW2ListEditDiscription.Location = new System.Drawing.Point(6, 22);
-            this.lblFLW2ListEditDiscription.Name = "lblFLW2ListEditDiscription";
-            this.lblFLW2ListEditDiscription.Size = new System.Drawing.Size(135, 12);
-            this.lblFLW2ListEditDiscription.TabIndex = 0;
-            this.lblFLW2ListEditDiscription.Text = "この項目は名前が不要です";
-            // 
-            // gbxListEditMSBT
-            // 
-            this.gbxListEditMSBT.Controls.Add(this.lblMSBTListEditDiscription);
-            this.gbxListEditMSBT.Controls.Add(this.lblMSBTListName);
-            this.gbxListEditMSBT.Controls.Add(this.txtSelectedMSBTListName);
-            this.gbxListEditMSBT.Controls.Add(this.lblMSBTListEditNote);
-            this.gbxListEditMSBT.Controls.Add(this.btnDeleteMSBTList);
-            this.gbxListEditMSBT.Controls.Add(this.txtMSBTListName);
-            this.gbxListEditMSBT.Controls.Add(this.btnAddMSBTList);
-            this.gbxListEditMSBT.Location = new System.Drawing.Point(3, 6);
-            this.gbxListEditMSBT.Name = "gbxListEditMSBT";
-            this.gbxListEditMSBT.Size = new System.Drawing.Size(224, 152);
-            this.gbxListEditMSBT.TabIndex = 4;
-            this.gbxListEditMSBT.TabStop = false;
-            this.gbxListEditMSBT.Text = "MSBT";
-            // 
-            // lblMSBTListEditDiscription
-            // 
-            this.lblMSBTListEditDiscription.AutoSize = true;
-            this.lblMSBTListEditDiscription.Location = new System.Drawing.Point(6, 39);
-            this.lblMSBTListEditDiscription.Name = "lblMSBTListEditDiscription";
-            this.lblMSBTListEditDiscription.Size = new System.Drawing.Size(142, 24);
-            this.lblMSBTListEditDiscription.TabIndex = 4;
-            this.lblMSBTListEditDiscription.Text = "削除は対象のリスト選択後に\r\n右の削除ボタンを押す";
-            // 
-            // lblMSBTListName
-            // 
-            this.lblMSBTListName.AutoSize = true;
-            this.lblMSBTListName.Location = new System.Drawing.Point(6, 15);
-            this.lblMSBTListName.Name = "lblMSBTListName";
-            this.lblMSBTListName.Size = new System.Drawing.Size(115, 12);
-            this.lblMSBTListName.TabIndex = 3;
-            this.lblMSBTListName.Text = "追加するMSBTリスト名";
-            // 
-            // txtSelectedMSBTListName
-            // 
-            this.txtSelectedMSBTListName.Location = new System.Drawing.Point(8, 116);
-            this.txtSelectedMSBTListName.Name = "txtSelectedMSBTListName";
-            this.txtSelectedMSBTListName.ReadOnly = true;
-            this.txtSelectedMSBTListName.Size = new System.Drawing.Size(204, 19);
-            this.txtSelectedMSBTListName.TabIndex = 1;
-            this.txtSelectedMSBTListName.MouseClick += new System.Windows.Forms.MouseEventHandler(this.textBox30_MouseClick);
-            this.txtSelectedMSBTListName.TextChanged += new System.EventHandler(this.textBox30_TextChanged);
-            // 
-            // lblMSBTListEditNote
-            // 
-            this.lblMSBTListEditNote.AutoSize = true;
-            this.lblMSBTListEditNote.ForeColor = System.Drawing.Color.Red;
-            this.lblMSBTListEditNote.Location = new System.Drawing.Point(6, 27);
-            this.lblMSBTListEditNote.Name = "lblMSBTListEditNote";
-            this.lblMSBTListEditNote.Size = new System.Drawing.Size(176, 12);
-            this.lblMSBTListEditNote.TabIndex = 5;
-            this.lblMSBTListEditNote.Text = "※ゲームの命名規則を守ってください";
-            // 
-            // btnDeleteMSBTList
-            // 
-            this.btnDeleteMSBTList.Location = new System.Drawing.Point(137, 91);
-            this.btnDeleteMSBTList.Name = "btnDeleteMSBTList";
-            this.btnDeleteMSBTList.Size = new System.Drawing.Size(75, 19);
-            this.btnDeleteMSBTList.TabIndex = 2;
-            this.btnDeleteMSBTList.Text = "削除";
-            this.btnDeleteMSBTList.UseVisualStyleBackColor = true;
-            this.btnDeleteMSBTList.Click += new System.EventHandler(this.BtnDeleteMSBTList_Click);
-            // 
-            // txtMSBTListName
-            // 
-            this.txtMSBTListName.Location = new System.Drawing.Point(8, 66);
-            this.txtMSBTListName.Name = "txtMSBTListName";
-            this.txtMSBTListName.Size = new System.Drawing.Size(204, 19);
-            this.txtMSBTListName.TabIndex = 0;
-            this.txtMSBTListName.TextChanged += new System.EventHandler(this.TxtMSBTListName_TextChanged);
-            // 
-            // btnAddMSBTList
-            // 
-            this.btnAddMSBTList.Location = new System.Drawing.Point(8, 91);
-            this.btnAddMSBTList.Name = "btnAddMSBTList";
-            this.btnAddMSBTList.Size = new System.Drawing.Size(75, 19);
-            this.btnAddMSBTList.TabIndex = 1;
-            this.btnAddMSBTList.Text = "追加";
-            this.btnAddMSBTList.UseVisualStyleBackColor = true;
-            this.btnAddMSBTList.Click += new System.EventHandler(this.BtnAddMSBTList_Click);
-            // 
-            // tbpMSBFSetting
-            // 
-            this.tbpMSBFSetting.Controls.Add(this.chkShowTvwMSBFFlow);
-            this.tbpMSBFSetting.Controls.Add(this.btnReloadTvwMSBFFlow);
-            this.tbpMSBFSetting.Controls.Add(this.txtReadOnlyMSBTText);
-            this.tbpMSBFSetting.Controls.Add(this.lblMSBFFlow);
-            this.tbpMSBFSetting.Controls.Add(this.tvwMSBFFlow);
-            this.tbpMSBFSetting.Controls.Add(this.lblMSBFSettingNote);
-            this.tbpMSBFSetting.Controls.Add(this.gbxFEN1);
-            this.tbpMSBFSetting.Controls.Add(this.gbxFLW2);
-            this.tbpMSBFSetting.Location = new System.Drawing.Point(4, 22);
-            this.tbpMSBFSetting.Name = "tbpMSBFSetting";
-            this.tbpMSBFSetting.Padding = new System.Windows.Forms.Padding(3);
-            this.tbpMSBFSetting.Size = new System.Drawing.Size(560, 434);
-            this.tbpMSBFSetting.TabIndex = 3;
-            this.tbpMSBFSetting.Text = "MSBF";
-            this.tbpMSBFSetting.UseVisualStyleBackColor = true;
-            // 
-            // chkShowTvwMSBFFlow
-            // 
-            this.chkShowTvwMSBFFlow.AutoSize = true;
-            this.chkShowTvwMSBFFlow.Location = new System.Drawing.Point(464, 9);
-            this.chkShowTvwMSBFFlow.Name = "chkShowTvwMSBFFlow";
-            this.chkShowTvwMSBFFlow.Size = new System.Drawing.Size(40, 16);
-            this.chkShowTvwMSBFFlow.TabIndex = 19;
-            this.chkShowTvwMSBFFlow.Text = "ON";
-            this.chkShowTvwMSBFFlow.UseVisualStyleBackColor = true;
-            this.chkShowTvwMSBFFlow.CheckedChanged += new System.EventHandler(this.ChkShowTvwMSBFFlow_CheckedChanged);
-            // 
-            // btnReloadTvwMSBFFlow
-            // 
-            this.btnReloadTvwMSBFFlow.Location = new System.Drawing.Point(439, 341);
-            this.btnReloadTvwMSBFFlow.Name = "btnReloadTvwMSBFFlow";
-            this.btnReloadTvwMSBFFlow.Size = new System.Drawing.Size(115, 23);
-            this.btnReloadTvwMSBFFlow.TabIndex = 18;
-            this.btnReloadTvwMSBFFlow.Text = "アップデート/Reload ";
-            this.btnReloadTvwMSBFFlow.UseVisualStyleBackColor = true;
-            this.btnReloadTvwMSBFFlow.Click += new System.EventHandler(this.BtnReloadTvwMSBFFlow_Click);
-            // 
-            // txtReadOnlyMSBTText
-            // 
-            this.txtReadOnlyMSBTText.Location = new System.Drawing.Point(6, 370);
-            this.txtReadOnlyMSBTText.Multiline = true;
-            this.txtReadOnlyMSBTText.Name = "txtReadOnlyMSBTText";
-            this.txtReadOnlyMSBTText.ReadOnly = true;
-            this.txtReadOnlyMSBTText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtReadOnlyMSBTText.Size = new System.Drawing.Size(548, 58);
-            this.txtReadOnlyMSBTText.TabIndex = 17;
-            this.txtReadOnlyMSBTText.TextChanged += new System.EventHandler(this.TxtReadOnlyMSBTText_TextChanged);
-            // 
-            // lblMSBFFlow
-            // 
-            this.lblMSBFFlow.AutoSize = true;
-            this.lblMSBFFlow.Location = new System.Drawing.Point(329, 10);
-            this.lblMSBFFlow.Name = "lblMSBFFlow";
-            this.lblMSBFFlow.Size = new System.Drawing.Size(129, 12);
-            this.lblMSBFFlow.TabIndex = 16;
-            this.lblMSBFFlow.Text = "テスト機能/Test function";
-            // 
-            // tvwMSBFFlow
-            // 
-            this.tvwMSBFFlow.Location = new System.Drawing.Point(329, 28);
-            this.tvwMSBFFlow.Name = "tvwMSBFFlow";
-            this.tvwMSBFFlow.Size = new System.Drawing.Size(225, 304);
-            this.tvwMSBFFlow.TabIndex = 15;
-            this.tvwMSBFFlow.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.TvwMSBFFlow_AfterSelect);
-            // 
-            // lblMSBFSettingNote
-            // 
-            this.lblMSBFSettingNote.AutoSize = true;
-            this.lblMSBFSettingNote.Location = new System.Drawing.Point(6, 335);
-            this.lblMSBFSettingNote.Name = "lblMSBFSettingNote";
-            this.lblMSBFSettingNote.Size = new System.Drawing.Size(210, 24);
-            this.lblMSBFSettingNote.TabIndex = 14;
-            this.lblMSBFSettingNote.Text = "※まだすべての機能が解明できていないので\r\n　不具合が発生する可能性があります";
-            // 
-            // gbxFEN1
-            // 
-            this.gbxFEN1.Controls.Add(this.lblFLW2StartIndex);
-            this.gbxFEN1.Controls.Add(this.lblFEN1Arg0);
-            this.gbxFEN1.Controls.Add(this.txtFEN1StartIndex);
-            this.gbxFEN1.Controls.Add(this.txtFEN1Arg0);
-            this.gbxFEN1.Location = new System.Drawing.Point(6, 262);
-            this.gbxFEN1.Name = "gbxFEN1";
-            this.gbxFEN1.Size = new System.Drawing.Size(317, 70);
-            this.gbxFEN1.TabIndex = 13;
-            this.gbxFEN1.TabStop = false;
-            this.gbxFEN1.Text = "FEN1";
-            // 
-            // lblFLW2StartIndex
-            // 
-            this.lblFLW2StartIndex.AutoSize = true;
-            this.lblFLW2StartIndex.Location = new System.Drawing.Point(6, 42);
-            this.lblFLW2StartIndex.Name = "lblFLW2StartIndex";
-            this.lblFLW2StartIndex.Size = new System.Drawing.Size(109, 12);
-            this.lblFLW2StartIndex.TabIndex = 4;
-            this.lblFLW2StartIndex.Text = "FLW2開始インデックス";
-            // 
-            // lblFEN1Arg0
-            // 
-            this.lblFEN1Arg0.AutoSize = true;
-            this.lblFEN1Arg0.Location = new System.Drawing.Point(6, 18);
-            this.lblFEN1Arg0.Name = "lblFEN1Arg0";
-            this.lblFEN1Arg0.Size = new System.Drawing.Size(29, 12);
-            this.lblFEN1Arg0.TabIndex = 3;
-            this.lblFEN1Arg0.Text = "不明";
-            // 
-            // txtFEN1StartIndex
-            // 
-            this.txtFEN1StartIndex.Location = new System.Drawing.Point(178, 39);
-            this.txtFEN1StartIndex.Name = "txtFEN1StartIndex";
-            this.txtFEN1StartIndex.Size = new System.Drawing.Size(100, 19);
-            this.txtFEN1StartIndex.TabIndex = 2;
-            this.txtFEN1StartIndex.TextChanged += new System.EventHandler(this.TxtFEN1StartIndex_TextChanged);
-            // 
-            // txtFEN1Arg0
-            // 
-            this.txtFEN1Arg0.Enabled = false;
-            this.txtFEN1Arg0.Location = new System.Drawing.Point(178, 15);
-            this.txtFEN1Arg0.Name = "txtFEN1Arg0";
-            this.txtFEN1Arg0.Size = new System.Drawing.Size(100, 19);
-            this.txtFEN1Arg0.TabIndex = 1;
-            this.txtFEN1Arg0.TextChanged += new System.EventHandler(this.TxtFEN1Arg0_TextChanged);
-            // 
-            // gbxFLW2
-            // 
-            this.gbxFLW2.Controls.Add(this.label41);
-            this.gbxFLW2.Controls.Add(this.gbxFLW2Branch);
-            this.gbxFLW2.Controls.Add(this.lblFLW2Arg4);
-            this.gbxFLW2.Controls.Add(this.lblFLW2Arg3);
-            this.gbxFLW2.Controls.Add(this.lblFLW2Arg2);
-            this.gbxFLW2.Controls.Add(this.lblFLW2Arg1);
-            this.gbxFLW2.Controls.Add(this.txtFLW2Arg4);
-            this.gbxFLW2.Controls.Add(this.txtFLW2Arg3);
-            this.gbxFLW2.Controls.Add(this.txtFLW2Arg2);
-            this.gbxFLW2.Controls.Add(this.txtFLW2Arg1);
-            this.gbxFLW2.Controls.Add(this.txtFLW2Padding);
-            this.gbxFLW2.Controls.Add(this.lblFLW2Padding);
-            this.gbxFLW2.Controls.Add(this.txtFLW2FlowType);
-            this.gbxFLW2.Controls.Add(this.lblFLW2FlowType);
-            this.gbxFLW2.Location = new System.Drawing.Point(6, 10);
-            this.gbxFLW2.Name = "gbxFLW2";
-            this.gbxFLW2.Size = new System.Drawing.Size(317, 246);
-            this.gbxFLW2.TabIndex = 1;
-            this.gbxFLW2.TabStop = false;
-            this.gbxFLW2.Text = "FLW2";
-            // 
-            // label41
-            // 
-            this.label41.AutoSize = true;
-            this.label41.Location = new System.Drawing.Point(6, 37);
-            this.label41.Name = "label41";
-            this.label41.Size = new System.Drawing.Size(17, 12);
-            this.label41.TabIndex = 13;
-            this.label41.Text = "∟";
-            // 
-            // gbxFLW2Branch
-            // 
-            this.gbxFLW2Branch.Controls.Add(this.txtFLW2BranchFalse);
-            this.gbxFLW2Branch.Controls.Add(this.txtFLW2BranchTrue);
-            this.gbxFLW2Branch.Controls.Add(this.lblFLW2BranchFalse);
-            this.gbxFLW2Branch.Controls.Add(this.lblFLW2BranchTrue);
-            this.gbxFLW2Branch.Location = new System.Drawing.Point(28, 37);
-            this.gbxFLW2Branch.Name = "gbxFLW2Branch";
-            this.gbxFLW2Branch.Size = new System.Drawing.Size(269, 70);
-            this.gbxFLW2Branch.TabIndex = 12;
-            this.gbxFLW2Branch.TabStop = false;
-            this.gbxFLW2Branch.Text = "フロータイプ2の場合のみ";
-            // 
-            // txtFLW2BranchFalse
-            // 
-            this.txtFLW2BranchFalse.Location = new System.Drawing.Point(150, 41);
-            this.txtFLW2BranchFalse.MaxLength = 4;
-            this.txtFLW2BranchFalse.Name = "txtFLW2BranchFalse";
-            this.txtFLW2BranchFalse.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2BranchFalse.TabIndex = 3;
-            this.txtFLW2BranchFalse.TextChanged += new System.EventHandler(this.TxtFLW2BranchFalse_TextChanged);
-            this.txtFLW2BranchFalse.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2BranchTrue_KeyPress);
-            // 
-            // txtFLW2BranchTrue
-            // 
-            this.txtFLW2BranchTrue.Location = new System.Drawing.Point(150, 16);
-            this.txtFLW2BranchTrue.MaxLength = 4;
-            this.txtFLW2BranchTrue.Name = "txtFLW2BranchTrue";
-            this.txtFLW2BranchTrue.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2BranchTrue.TabIndex = 2;
-            this.txtFLW2BranchTrue.TextChanged += new System.EventHandler(this.TxtFLW2BranchTrue_TextChanged);
-            this.txtFLW2BranchTrue.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2BranchTrue_KeyPress);
-            // 
-            // lblFLW2BranchFalse
-            // 
-            this.lblFLW2BranchFalse.AutoSize = true;
-            this.lblFLW2BranchFalse.Location = new System.Drawing.Point(6, 44);
-            this.lblFLW2BranchFalse.Name = "lblFLW2BranchFalse";
-            this.lblFLW2BranchFalse.Size = new System.Drawing.Size(59, 12);
-            this.lblFLW2BranchFalse.TabIndex = 1;
-            this.lblFLW2BranchFalse.Text = "ジャンプ先2";
-            // 
-            // lblFLW2BranchTrue
-            // 
-            this.lblFLW2BranchTrue.AutoSize = true;
-            this.lblFLW2BranchTrue.Location = new System.Drawing.Point(6, 19);
-            this.lblFLW2BranchTrue.Name = "lblFLW2BranchTrue";
-            this.lblFLW2BranchTrue.Size = new System.Drawing.Size(59, 12);
-            this.lblFLW2BranchTrue.TabIndex = 0;
-            this.lblFLW2BranchTrue.Text = "ジャンプ先1";
-            // 
-            // lblFLW2Arg4
-            // 
-            this.lblFLW2Arg4.AutoSize = true;
-            this.lblFLW2Arg4.Location = new System.Drawing.Point(6, 218);
-            this.lblFLW2Arg4.Name = "lblFLW2Arg4";
-            this.lblFLW2Arg4.Size = new System.Drawing.Size(35, 12);
-            this.lblFLW2Arg4.TabIndex = 11;
-            this.lblFLW2Arg4.Text = "不明5";
-            // 
-            // lblFLW2Arg3
-            // 
-            this.lblFLW2Arg3.AutoSize = true;
-            this.lblFLW2Arg3.Location = new System.Drawing.Point(6, 193);
-            this.lblFLW2Arg3.Name = "lblFLW2Arg3";
-            this.lblFLW2Arg3.Size = new System.Drawing.Size(35, 12);
-            this.lblFLW2Arg3.TabIndex = 10;
-            this.lblFLW2Arg3.Text = "不明4";
-            // 
-            // lblFLW2Arg2
-            // 
-            this.lblFLW2Arg2.AutoSize = true;
-            this.lblFLW2Arg2.Location = new System.Drawing.Point(6, 168);
-            this.lblFLW2Arg2.Name = "lblFLW2Arg2";
-            this.lblFLW2Arg2.Size = new System.Drawing.Size(35, 12);
-            this.lblFLW2Arg2.TabIndex = 9;
-            this.lblFLW2Arg2.Text = "不明3";
-            // 
-            // lblFLW2Arg1
-            // 
-            this.lblFLW2Arg1.AutoSize = true;
-            this.lblFLW2Arg1.Location = new System.Drawing.Point(6, 143);
-            this.lblFLW2Arg1.Name = "lblFLW2Arg1";
-            this.lblFLW2Arg1.Size = new System.Drawing.Size(35, 12);
-            this.lblFLW2Arg1.TabIndex = 8;
-            this.lblFLW2Arg1.Text = "不明2";
-            // 
-            // txtFLW2Arg4
-            // 
-            this.txtFLW2Arg4.Location = new System.Drawing.Point(178, 215);
-            this.txtFLW2Arg4.MaxLength = 4;
-            this.txtFLW2Arg4.Name = "txtFLW2Arg4";
-            this.txtFLW2Arg4.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2Arg4.TabIndex = 7;
-            this.txtFLW2Arg4.TextChanged += new System.EventHandler(this.TxtFLW2Arg4_TextChanged);
-            this.txtFLW2Arg4.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2BranchTrue_KeyPress);
-            // 
-            // txtFLW2Arg3
-            // 
-            this.txtFLW2Arg3.Location = new System.Drawing.Point(178, 190);
-            this.txtFLW2Arg3.MaxLength = 4;
-            this.txtFLW2Arg3.Name = "txtFLW2Arg3";
-            this.txtFLW2Arg3.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2Arg3.TabIndex = 6;
-            this.txtFLW2Arg3.TextChanged += new System.EventHandler(this.TxtFLW2Arg3_TextChanged);
-            this.txtFLW2Arg3.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2BranchTrue_KeyPress);
-            // 
-            // txtFLW2Arg2
-            // 
-            this.txtFLW2Arg2.Location = new System.Drawing.Point(178, 165);
-            this.txtFLW2Arg2.MaxLength = 4;
-            this.txtFLW2Arg2.Name = "txtFLW2Arg2";
-            this.txtFLW2Arg2.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2Arg2.TabIndex = 5;
-            this.txtFLW2Arg2.TextChanged += new System.EventHandler(this.TxtFLW2Arg2_TextChanged);
-            this.txtFLW2Arg2.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2BranchTrue_KeyPress);
-            // 
-            // txtFLW2Arg1
-            // 
-            this.txtFLW2Arg1.Location = new System.Drawing.Point(178, 140);
-            this.txtFLW2Arg1.MaxLength = 4;
-            this.txtFLW2Arg1.Name = "txtFLW2Arg1";
-            this.txtFLW2Arg1.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2Arg1.TabIndex = 4;
-            this.txtFLW2Arg1.TextChanged += new System.EventHandler(this.TxtFLW2Arg1_TextChanged);
-            this.txtFLW2Arg1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2BranchTrue_KeyPress);
-            // 
-            // txtFLW2Padding
-            // 
-            this.txtFLW2Padding.Location = new System.Drawing.Point(178, 115);
-            this.txtFLW2Padding.MaxLength = 4;
-            this.txtFLW2Padding.Name = "txtFLW2Padding";
-            this.txtFLW2Padding.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2Padding.TabIndex = 3;
-            this.txtFLW2Padding.TextChanged += new System.EventHandler(this.TxtFLW2Padding_TextChanged);
-            this.txtFLW2Padding.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2BranchTrue_KeyPress);
-            // 
-            // lblFLW2Padding
-            // 
-            this.lblFLW2Padding.AutoSize = true;
-            this.lblFLW2Padding.Location = new System.Drawing.Point(6, 118);
-            this.lblFLW2Padding.Name = "lblFLW2Padding";
-            this.lblFLW2Padding.Size = new System.Drawing.Size(62, 12);
-            this.lblFLW2Padding.TabIndex = 2;
-            this.lblFLW2Padding.Text = "パディング？";
-            // 
-            // txtFLW2FlowType
-            // 
-            this.txtFLW2FlowType.Location = new System.Drawing.Point(178, 12);
-            this.txtFLW2FlowType.MaxLength = 4;
-            this.txtFLW2FlowType.Name = "txtFLW2FlowType";
-            this.txtFLW2FlowType.Size = new System.Drawing.Size(100, 19);
-            this.txtFLW2FlowType.TabIndex = 1;
-            this.txtFLW2FlowType.TextChanged += new System.EventHandler(this.TxtFLW2FlowType_TextChanged);
-            this.txtFLW2FlowType.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFLW2FlowType_KeyPress);
-            // 
-            // lblFLW2FlowType
-            // 
-            this.lblFLW2FlowType.AutoSize = true;
-            this.lblFLW2FlowType.Location = new System.Drawing.Point(6, 15);
-            this.lblFLW2FlowType.Name = "lblFLW2FlowType";
-            this.lblFLW2FlowType.Size = new System.Drawing.Size(58, 12);
-            this.lblFLW2FlowType.TabIndex = 0;
-            this.lblFLW2FlowType.Text = "フロータイプ";
-            // 
-            // tbpDebugMSBF
-            // 
-            this.tbpDebugMSBF.Controls.Add(this.lblMSBFHashCalculator);
-            this.tbpDebugMSBF.Controls.Add(this.textBox34);
-            this.tbpDebugMSBF.Controls.Add(this.button30);
-            this.tbpDebugMSBF.Controls.Add(this.textBox33);
-            this.tbpDebugMSBF.Controls.Add(this.textBox32);
-            this.tbpDebugMSBF.Controls.Add(this.btnCalculateHash);
-            this.tbpDebugMSBF.Controls.Add(this.txtListNameToCalculateHash);
-            this.tbpDebugMSBF.Controls.Add(this.richTextBox1);
-            this.tbpDebugMSBF.Controls.Add(this.textBox13);
-            this.tbpDebugMSBF.Location = new System.Drawing.Point(4, 22);
-            this.tbpDebugMSBF.Name = "tbpDebugMSBF";
-            this.tbpDebugMSBF.Padding = new System.Windows.Forms.Padding(3);
-            this.tbpDebugMSBF.Size = new System.Drawing.Size(560, 434);
-            this.tbpDebugMSBF.TabIndex = 4;
-            this.tbpDebugMSBF.Text = "MSBFデバッグ";
-            this.tbpDebugMSBF.UseVisualStyleBackColor = true;
-            // 
-            // lblMSBFHashCalculator
-            // 
-            this.lblMSBFHashCalculator.AutoSize = true;
-            this.lblMSBFHashCalculator.Location = new System.Drawing.Point(6, 12);
-            this.lblMSBFHashCalculator.Name = "lblMSBFHashCalculator";
-            this.lblMSBFHashCalculator.Size = new System.Drawing.Size(107, 12);
-            this.lblMSBFHashCalculator.TabIndex = 16;
-            this.lblMSBFHashCalculator.Text = "MSBFハッシュ計算機";
-            this.lblMSBFHashCalculator.Click += new System.EventHandler(this.LblMSBFHashCalculator_Click);
+            // gbxListEditFen1
+            // 
+            this.gbxListEditFen1.Controls.Add(this.btnDeleteFen1List);
+            this.gbxListEditFen1.Controls.Add(this.btnAddFen1List);
+            this.gbxListEditFen1.Controls.Add(this.txtFen1ListName);
+            this.gbxListEditFen1.Controls.Add(this.lblFen1ListName);
+            this.gbxListEditFen1.Location = new System.Drawing.Point(3, 270);
+            this.gbxListEditFen1.Name = "gbxListEditFen1";
+            this.gbxListEditFen1.Size = new System.Drawing.Size(224, 119);
+            this.gbxListEditFen1.TabIndex = 6;
+            this.gbxListEditFen1.TabStop = false;
+            this.gbxListEditFen1.Text = "FEN1";
+            // 
+            // btnDeleteFen1List
+            // 
+            this.btnDeleteFen1List.Location = new System.Drawing.Point(137, 90);
+            this.btnDeleteFen1List.Name = "btnDeleteFen1List";
+            this.btnDeleteFen1List.Size = new System.Drawing.Size(75, 23);
+            this.btnDeleteFen1List.TabIndex = 3;
+            this.btnDeleteFen1List.Text = "削除";
+            this.btnDeleteFen1List.UseVisualStyleBackColor = true;
+            this.btnDeleteFen1List.Click += new System.EventHandler(this.BtnDeleteFen1List_Click);
+            // 
+            // btnAddFen1List
+            // 
+            this.btnAddFen1List.Location = new System.Drawing.Point(8, 90);
+            this.btnAddFen1List.Name = "btnAddFen1List";
+            this.btnAddFen1List.Size = new System.Drawing.Size(75, 23);
+            this.btnAddFen1List.TabIndex = 2;
+            this.btnAddFen1List.Text = "追加";
+            this.btnAddFen1List.UseVisualStyleBackColor = true;
+            this.btnAddFen1List.Click += new System.EventHandler(this.BtnAddFen1List_Click);
+            // 
+            // txtFen1ListName
+            // 
+            this.txtFen1ListName.Location = new System.Drawing.Point(8, 51);
+            this.txtFen1ListName.Name = "txtFen1ListName";
+            this.txtFen1ListName.Size = new System.Drawing.Size(204, 19);
+            this.txtFen1ListName.TabIndex = 1;
+            this.txtFen1ListName.TextChanged += new System.EventHandler(this.TxtFen1ListName_TextChanged);
+            // 
+            // lblFen1ListName
+            // 
+            this.lblFen1ListName.AutoSize = true;
+            this.lblFen1ListName.Location = new System.Drawing.Point(6, 19);
+            this.lblFen1ListName.Name = "lblFen1ListName";
+            this.lblFen1ListName.Size = new System.Drawing.Size(168, 12);
+            this.lblFen1ListName.TabIndex = 0;
+            this.lblFen1ListName.Text = "名前必須(Flowなどを省いた名前)";
+            // 
+            // gbxListEditFlw2
+            // 
+            this.gbxListEditFlw2.Controls.Add(this.btnDeleteFlw2List);
+            this.gbxListEditFlw2.Controls.Add(this.btnAddFlw2List);
+            this.gbxListEditFlw2.Controls.Add(this.lblFlw2ListEditDiscription);
+            this.gbxListEditFlw2.Location = new System.Drawing.Point(3, 164);
+            this.gbxListEditFlw2.Name = "gbxListEditFlw2";
+            this.gbxListEditFlw2.Size = new System.Drawing.Size(224, 100);
+            this.gbxListEditFlw2.TabIndex = 5;
+            this.gbxListEditFlw2.TabStop = false;
+            this.gbxListEditFlw2.Text = "FLW2";
+            // 
+            // btnDeleteFlw2List
+            // 
+            this.btnDeleteFlw2List.Location = new System.Drawing.Point(137, 58);
+            this.btnDeleteFlw2List.Name = "btnDeleteFlw2List";
+            this.btnDeleteFlw2List.Size = new System.Drawing.Size(75, 23);
+            this.btnDeleteFlw2List.TabIndex = 3;
+            this.btnDeleteFlw2List.Text = "削除";
+            this.btnDeleteFlw2List.UseVisualStyleBackColor = true;
+            this.btnDeleteFlw2List.Click += new System.EventHandler(this.BtnDeleteFlw2List_Click);
+            // 
+            // btnAddFlw2List
+            // 
+            this.btnAddFlw2List.Location = new System.Drawing.Point(8, 58);
+            this.btnAddFlw2List.Name = "btnAddFlw2List";
+            this.btnAddFlw2List.Size = new System.Drawing.Size(75, 23);
+            this.btnAddFlw2List.TabIndex = 2;
+            this.btnAddFlw2List.Text = "追加";
+            this.btnAddFlw2List.UseVisualStyleBackColor = true;
+            this.btnAddFlw2List.Click += new System.EventHandler(this.BtnAddFlw2List_Click);
+            // 
+            // lblFlw2ListEditDiscription
+            // 
+            this.lblFlw2ListEditDiscription.AutoSize = true;
+            this.lblFlw2ListEditDiscription.Location = new System.Drawing.Point(6, 22);
+            this.lblFlw2ListEditDiscription.Name = "lblFlw2ListEditDiscription";
+            this.lblFlw2ListEditDiscription.Size = new System.Drawing.Size(135, 12);
+            this.lblFlw2ListEditDiscription.TabIndex = 0;
+            this.lblFlw2ListEditDiscription.Text = "この項目は名前が不要です";
+            // 
+            // gbxListEditMsbt
+            // 
+            this.gbxListEditMsbt.Controls.Add(this.lblMsbtListEditDiscription);
+            this.gbxListEditMsbt.Controls.Add(this.lblMsbtListName);
+            this.gbxListEditMsbt.Controls.Add(this.txtSelectedMsbtListName);
+            this.gbxListEditMsbt.Controls.Add(this.lblMsbtListEditNote);
+            this.gbxListEditMsbt.Controls.Add(this.btnDeleteMsbtList);
+            this.gbxListEditMsbt.Controls.Add(this.txtMsbtListName);
+            this.gbxListEditMsbt.Controls.Add(this.btnAddMsbtList);
+            this.gbxListEditMsbt.Location = new System.Drawing.Point(3, 6);
+            this.gbxListEditMsbt.Name = "gbxListEditMsbt";
+            this.gbxListEditMsbt.Size = new System.Drawing.Size(224, 152);
+            this.gbxListEditMsbt.TabIndex = 4;
+            this.gbxListEditMsbt.TabStop = false;
+            this.gbxListEditMsbt.Text = "MSBT";
+            // 
+            // lblMsbtListEditDiscription
+            // 
+            this.lblMsbtListEditDiscription.AutoSize = true;
+            this.lblMsbtListEditDiscription.Location = new System.Drawing.Point(6, 39);
+            this.lblMsbtListEditDiscription.Name = "lblMsbtListEditDiscription";
+            this.lblMsbtListEditDiscription.Size = new System.Drawing.Size(142, 24);
+            this.lblMsbtListEditDiscription.TabIndex = 4;
+            this.lblMsbtListEditDiscription.Text = "削除は対象のリスト選択後に\r\n右の削除ボタンを押す";
+            // 
+            // lblMsbtListName
+            // 
+            this.lblMsbtListName.AutoSize = true;
+            this.lblMsbtListName.Location = new System.Drawing.Point(6, 15);
+            this.lblMsbtListName.Name = "lblMsbtListName";
+            this.lblMsbtListName.Size = new System.Drawing.Size(115, 12);
+            this.lblMsbtListName.TabIndex = 3;
+            this.lblMsbtListName.Text = "追加するMSBTリスト名";
+            // 
+            // txtSelectedMsbtListName
+            // 
+            this.txtSelectedMsbtListName.Location = new System.Drawing.Point(8, 116);
+            this.txtSelectedMsbtListName.Name = "txtSelectedMsbtListName";
+            this.txtSelectedMsbtListName.ReadOnly = true;
+            this.txtSelectedMsbtListName.Size = new System.Drawing.Size(204, 19);
+            this.txtSelectedMsbtListName.TabIndex = 1;
+            this.txtSelectedMsbtListName.MouseClick += new System.Windows.Forms.MouseEventHandler(this.textBox30_MouseClick);
+            this.txtSelectedMsbtListName.TextChanged += new System.EventHandler(this.textBox30_TextChanged);
+            // 
+            // lblMsbtListEditNote
+            // 
+            this.lblMsbtListEditNote.AutoSize = true;
+            this.lblMsbtListEditNote.ForeColor = System.Drawing.Color.Red;
+            this.lblMsbtListEditNote.Location = new System.Drawing.Point(6, 27);
+            this.lblMsbtListEditNote.Name = "lblMsbtListEditNote";
+            this.lblMsbtListEditNote.Size = new System.Drawing.Size(176, 12);
+            this.lblMsbtListEditNote.TabIndex = 5;
+            this.lblMsbtListEditNote.Text = "※ゲームの命名規則を守ってください";
+            // 
+            // btnDeleteMsbtList
+            // 
+            this.btnDeleteMsbtList.Location = new System.Drawing.Point(137, 91);
+            this.btnDeleteMsbtList.Name = "btnDeleteMsbtList";
+            this.btnDeleteMsbtList.Size = new System.Drawing.Size(75, 19);
+            this.btnDeleteMsbtList.TabIndex = 2;
+            this.btnDeleteMsbtList.Text = "削除";
+            this.btnDeleteMsbtList.UseVisualStyleBackColor = true;
+            this.btnDeleteMsbtList.Click += new System.EventHandler(this.BtnDeleteMsbtList_Click);
+            // 
+            // txtMsbtListName
+            // 
+            this.txtMsbtListName.Location = new System.Drawing.Point(8, 66);
+            this.txtMsbtListName.Name = "txtMsbtListName";
+            this.txtMsbtListName.Size = new System.Drawing.Size(204, 19);
+            this.txtMsbtListName.TabIndex = 0;
+            this.txtMsbtListName.TextChanged += new System.EventHandler(this.TxtMsbtListName_TextChanged);
+            // 
+            // btnAddMsbtList
+            // 
+            this.btnAddMsbtList.Location = new System.Drawing.Point(8, 91);
+            this.btnAddMsbtList.Name = "btnAddMsbtList";
+            this.btnAddMsbtList.Size = new System.Drawing.Size(75, 19);
+            this.btnAddMsbtList.TabIndex = 1;
+            this.btnAddMsbtList.Text = "追加";
+            this.btnAddMsbtList.UseVisualStyleBackColor = true;
+            this.btnAddMsbtList.Click += new System.EventHandler(this.BtnAddMsbtList_Click);
+            // 
+            // tbpMsbfSetting
+            // 
+            this.tbpMsbfSetting.Controls.Add(this.chkShowTvwMsbfFlow);
+            this.tbpMsbfSetting.Controls.Add(this.btnReloadTvwMsbfFlow);
+            this.tbpMsbfSetting.Controls.Add(this.txtReadOnlyMsbtText);
+            this.tbpMsbfSetting.Controls.Add(this.lblMsbfFlow);
+            this.tbpMsbfSetting.Controls.Add(this.tvwMsbfFlow);
+            this.tbpMsbfSetting.Controls.Add(this.lblMsbfSettingNote);
+            this.tbpMsbfSetting.Controls.Add(this.gbxFen1);
+            this.tbpMsbfSetting.Controls.Add(this.gbxFlw2);
+            this.tbpMsbfSetting.Location = new System.Drawing.Point(4, 22);
+            this.tbpMsbfSetting.Name = "tbpMsbfSetting";
+            this.tbpMsbfSetting.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpMsbfSetting.Size = new System.Drawing.Size(560, 434);
+            this.tbpMsbfSetting.TabIndex = 3;
+            this.tbpMsbfSetting.Text = "MSBF";
+            this.tbpMsbfSetting.UseVisualStyleBackColor = true;
+            // 
+            // chkShowTvwMsbfFlow
+            // 
+            this.chkShowTvwMsbfFlow.AutoSize = true;
+            this.chkShowTvwMsbfFlow.Location = new System.Drawing.Point(464, 9);
+            this.chkShowTvwMsbfFlow.Name = "chkShowTvwMsbfFlow";
+            this.chkShowTvwMsbfFlow.Size = new System.Drawing.Size(40, 16);
+            this.chkShowTvwMsbfFlow.TabIndex = 19;
+            this.chkShowTvwMsbfFlow.Text = "ON";
+            this.chkShowTvwMsbfFlow.UseVisualStyleBackColor = true;
+            this.chkShowTvwMsbfFlow.CheckedChanged += new System.EventHandler(this.ChkShowTvwMsbfFlow_CheckedChanged);
+            // 
+            // btnReloadTvwMsbfFlow
+            // 
+            this.btnReloadTvwMsbfFlow.Location = new System.Drawing.Point(439, 341);
+            this.btnReloadTvwMsbfFlow.Name = "btnReloadTvwMsbfFlow";
+            this.btnReloadTvwMsbfFlow.Size = new System.Drawing.Size(115, 23);
+            this.btnReloadTvwMsbfFlow.TabIndex = 18;
+            this.btnReloadTvwMsbfFlow.Text = "アップデート/Reload ";
+            this.btnReloadTvwMsbfFlow.UseVisualStyleBackColor = true;
+            this.btnReloadTvwMsbfFlow.Click += new System.EventHandler(this.BtnReloadTvwMsbfFlow_Click);
+            // 
+            // txtReadOnlyMsbtText
+            // 
+            this.txtReadOnlyMsbtText.Location = new System.Drawing.Point(6, 370);
+            this.txtReadOnlyMsbtText.Multiline = true;
+            this.txtReadOnlyMsbtText.Name = "txtReadOnlyMsbtText";
+            this.txtReadOnlyMsbtText.ReadOnly = true;
+            this.txtReadOnlyMsbtText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtReadOnlyMsbtText.Size = new System.Drawing.Size(548, 58);
+            this.txtReadOnlyMsbtText.TabIndex = 17;
+            this.txtReadOnlyMsbtText.TextChanged += new System.EventHandler(this.TxtReadOnlyMsbtText_TextChanged);
+            // 
+            // lblMsbfFlow
+            // 
+            this.lblMsbfFlow.AutoSize = true;
+            this.lblMsbfFlow.Location = new System.Drawing.Point(329, 10);
+            this.lblMsbfFlow.Name = "lblMsbfFlow";
+            this.lblMsbfFlow.Size = new System.Drawing.Size(129, 12);
+            this.lblMsbfFlow.TabIndex = 16;
+            this.lblMsbfFlow.Text = "テスト機能/Test function";
+            // 
+            // tvwMsbfFlow
+            // 
+            this.tvwMsbfFlow.Location = new System.Drawing.Point(329, 28);
+            this.tvwMsbfFlow.Name = "tvwMsbfFlow";
+            this.tvwMsbfFlow.Size = new System.Drawing.Size(225, 304);
+            this.tvwMsbfFlow.TabIndex = 15;
+            this.tvwMsbfFlow.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.TvwMsbfFlow_AfterSelect);
+            // 
+            // lblMsbfSettingNote
+            // 
+            this.lblMsbfSettingNote.AutoSize = true;
+            this.lblMsbfSettingNote.Location = new System.Drawing.Point(6, 335);
+            this.lblMsbfSettingNote.Name = "lblMsbfSettingNote";
+            this.lblMsbfSettingNote.Size = new System.Drawing.Size(210, 24);
+            this.lblMsbfSettingNote.TabIndex = 14;
+            this.lblMsbfSettingNote.Text = "※まだすべての機能が解明できていないので\r\n　不具合が発生する可能性があります";
+            // 
+            // gbxFen1
+            // 
+            this.gbxFen1.Controls.Add(this.lblFlw2StartIndex);
+            this.gbxFen1.Controls.Add(this.lblFen1Arg0);
+            this.gbxFen1.Controls.Add(this.txtFen1StartIndex);
+            this.gbxFen1.Controls.Add(this.txtFen1Arg0);
+            this.gbxFen1.Location = new System.Drawing.Point(6, 262);
+            this.gbxFen1.Name = "gbxFen1";
+            this.gbxFen1.Size = new System.Drawing.Size(317, 70);
+            this.gbxFen1.TabIndex = 13;
+            this.gbxFen1.TabStop = false;
+            this.gbxFen1.Text = "FEN1";
+            // 
+            // lblFlw2StartIndex
+            // 
+            this.lblFlw2StartIndex.AutoSize = true;
+            this.lblFlw2StartIndex.Location = new System.Drawing.Point(6, 42);
+            this.lblFlw2StartIndex.Name = "lblFlw2StartIndex";
+            this.lblFlw2StartIndex.Size = new System.Drawing.Size(109, 12);
+            this.lblFlw2StartIndex.TabIndex = 4;
+            this.lblFlw2StartIndex.Text = "FLW2開始インデックス";
+            // 
+            // lblFen1Arg0
+            // 
+            this.lblFen1Arg0.AutoSize = true;
+            this.lblFen1Arg0.Location = new System.Drawing.Point(6, 18);
+            this.lblFen1Arg0.Name = "lblFen1Arg0";
+            this.lblFen1Arg0.Size = new System.Drawing.Size(29, 12);
+            this.lblFen1Arg0.TabIndex = 3;
+            this.lblFen1Arg0.Text = "不明";
+            // 
+            // txtFen1StartIndex
+            // 
+            this.txtFen1StartIndex.Location = new System.Drawing.Point(178, 39);
+            this.txtFen1StartIndex.Name = "txtFen1StartIndex";
+            this.txtFen1StartIndex.Size = new System.Drawing.Size(100, 19);
+            this.txtFen1StartIndex.TabIndex = 2;
+            this.txtFen1StartIndex.TextChanged += new System.EventHandler(this.TxtFen1StartIndex_TextChanged);
+            // 
+            // txtFen1Arg0
+            // 
+            this.txtFen1Arg0.Enabled = false;
+            this.txtFen1Arg0.Location = new System.Drawing.Point(178, 15);
+            this.txtFen1Arg0.Name = "txtFen1Arg0";
+            this.txtFen1Arg0.Size = new System.Drawing.Size(100, 19);
+            this.txtFen1Arg0.TabIndex = 1;
+            this.txtFen1Arg0.TextChanged += new System.EventHandler(this.TxtFen1Arg0_TextChanged);
+            // 
+            // gbxFlw2
+            // 
+            this.gbxFlw2.Controls.Add(this.lblFlw2RightAngleSymbol);
+            this.gbxFlw2.Controls.Add(this.gbxFlw2Branch);
+            this.gbxFlw2.Controls.Add(this.lblFlw2Arg4);
+            this.gbxFlw2.Controls.Add(this.lblFlw2Arg3);
+            this.gbxFlw2.Controls.Add(this.lblFlw2Arg2);
+            this.gbxFlw2.Controls.Add(this.lblFlw2Arg1);
+            this.gbxFlw2.Controls.Add(this.txtFlw2Arg4);
+            this.gbxFlw2.Controls.Add(this.txtFlw2Arg3);
+            this.gbxFlw2.Controls.Add(this.txtFlw2Arg2);
+            this.gbxFlw2.Controls.Add(this.txtFlw2Arg1);
+            this.gbxFlw2.Controls.Add(this.txtFlw2Padding);
+            this.gbxFlw2.Controls.Add(this.lblFlw2Padding);
+            this.gbxFlw2.Controls.Add(this.txtFlw2FlowType);
+            this.gbxFlw2.Controls.Add(this.lblFlw2FlowType);
+            this.gbxFlw2.Location = new System.Drawing.Point(6, 10);
+            this.gbxFlw2.Name = "gbxFlw2";
+            this.gbxFlw2.Size = new System.Drawing.Size(317, 246);
+            this.gbxFlw2.TabIndex = 1;
+            this.gbxFlw2.TabStop = false;
+            this.gbxFlw2.Text = "FLW2";
+            // 
+            // lblFlw2RightAngleSymbol
+            // 
+            this.lblFlw2RightAngleSymbol.AutoSize = true;
+            this.lblFlw2RightAngleSymbol.Location = new System.Drawing.Point(6, 37);
+            this.lblFlw2RightAngleSymbol.Name = "lblFlw2RightAngleSymbol";
+            this.lblFlw2RightAngleSymbol.Size = new System.Drawing.Size(17, 12);
+            this.lblFlw2RightAngleSymbol.TabIndex = 13;
+            this.lblFlw2RightAngleSymbol.Text = "∟";
+            // 
+            // gbxFlw2Branch
+            // 
+            this.gbxFlw2Branch.Controls.Add(this.txtFlw2BranchFalse);
+            this.gbxFlw2Branch.Controls.Add(this.txtFlw2BranchTrue);
+            this.gbxFlw2Branch.Controls.Add(this.lblFlw2BranchFalse);
+            this.gbxFlw2Branch.Controls.Add(this.lblFlw2BranchTrue);
+            this.gbxFlw2Branch.Location = new System.Drawing.Point(28, 37);
+            this.gbxFlw2Branch.Name = "gbxFlw2Branch";
+            this.gbxFlw2Branch.Size = new System.Drawing.Size(269, 70);
+            this.gbxFlw2Branch.TabIndex = 12;
+            this.gbxFlw2Branch.TabStop = false;
+            this.gbxFlw2Branch.Text = "フロータイプ2の場合のみ";
+            // 
+            // txtFlw2BranchFalse
+            // 
+            this.txtFlw2BranchFalse.Location = new System.Drawing.Point(150, 41);
+            this.txtFlw2BranchFalse.MaxLength = 4;
+            this.txtFlw2BranchFalse.Name = "txtFlw2BranchFalse";
+            this.txtFlw2BranchFalse.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2BranchFalse.TabIndex = 3;
+            this.txtFlw2BranchFalse.TextChanged += new System.EventHandler(this.TxtFlw2BranchFalse_TextChanged);
+            this.txtFlw2BranchFalse.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2BranchTrue_KeyPress);
+            // 
+            // txtFlw2BranchTrue
+            // 
+            this.txtFlw2BranchTrue.Location = new System.Drawing.Point(150, 16);
+            this.txtFlw2BranchTrue.MaxLength = 4;
+            this.txtFlw2BranchTrue.Name = "txtFlw2BranchTrue";
+            this.txtFlw2BranchTrue.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2BranchTrue.TabIndex = 2;
+            this.txtFlw2BranchTrue.TextChanged += new System.EventHandler(this.TxtFlw2BranchTrue_TextChanged);
+            this.txtFlw2BranchTrue.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2BranchTrue_KeyPress);
+            // 
+            // lblFlw2BranchFalse
+            // 
+            this.lblFlw2BranchFalse.AutoSize = true;
+            this.lblFlw2BranchFalse.Location = new System.Drawing.Point(6, 44);
+            this.lblFlw2BranchFalse.Name = "lblFlw2BranchFalse";
+            this.lblFlw2BranchFalse.Size = new System.Drawing.Size(59, 12);
+            this.lblFlw2BranchFalse.TabIndex = 1;
+            this.lblFlw2BranchFalse.Text = "ジャンプ先2";
+            // 
+            // lblFlw2BranchTrue
+            // 
+            this.lblFlw2BranchTrue.AutoSize = true;
+            this.lblFlw2BranchTrue.Location = new System.Drawing.Point(6, 19);
+            this.lblFlw2BranchTrue.Name = "lblFlw2BranchTrue";
+            this.lblFlw2BranchTrue.Size = new System.Drawing.Size(59, 12);
+            this.lblFlw2BranchTrue.TabIndex = 0;
+            this.lblFlw2BranchTrue.Text = "ジャンプ先1";
+            // 
+            // lblFlw2Arg4
+            // 
+            this.lblFlw2Arg4.AutoSize = true;
+            this.lblFlw2Arg4.Location = new System.Drawing.Point(6, 218);
+            this.lblFlw2Arg4.Name = "lblFlw2Arg4";
+            this.lblFlw2Arg4.Size = new System.Drawing.Size(35, 12);
+            this.lblFlw2Arg4.TabIndex = 11;
+            this.lblFlw2Arg4.Text = "不明5";
+            // 
+            // lblFlw2Arg3
+            // 
+            this.lblFlw2Arg3.AutoSize = true;
+            this.lblFlw2Arg3.Location = new System.Drawing.Point(6, 193);
+            this.lblFlw2Arg3.Name = "lblFlw2Arg3";
+            this.lblFlw2Arg3.Size = new System.Drawing.Size(35, 12);
+            this.lblFlw2Arg3.TabIndex = 10;
+            this.lblFlw2Arg3.Text = "不明4";
+            // 
+            // lblFlw2Arg2
+            // 
+            this.lblFlw2Arg2.AutoSize = true;
+            this.lblFlw2Arg2.Location = new System.Drawing.Point(6, 168);
+            this.lblFlw2Arg2.Name = "lblFlw2Arg2";
+            this.lblFlw2Arg2.Size = new System.Drawing.Size(35, 12);
+            this.lblFlw2Arg2.TabIndex = 9;
+            this.lblFlw2Arg2.Text = "不明3";
+            // 
+            // lblFlw2Arg1
+            // 
+            this.lblFlw2Arg1.AutoSize = true;
+            this.lblFlw2Arg1.Location = new System.Drawing.Point(6, 143);
+            this.lblFlw2Arg1.Name = "lblFlw2Arg1";
+            this.lblFlw2Arg1.Size = new System.Drawing.Size(35, 12);
+            this.lblFlw2Arg1.TabIndex = 8;
+            this.lblFlw2Arg1.Text = "不明2";
+            // 
+            // txtFlw2Arg4
+            // 
+            this.txtFlw2Arg4.Location = new System.Drawing.Point(178, 215);
+            this.txtFlw2Arg4.MaxLength = 4;
+            this.txtFlw2Arg4.Name = "txtFlw2Arg4";
+            this.txtFlw2Arg4.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2Arg4.TabIndex = 7;
+            this.txtFlw2Arg4.TextChanged += new System.EventHandler(this.TxtFlw2Arg4_TextChanged);
+            this.txtFlw2Arg4.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2BranchTrue_KeyPress);
+            // 
+            // txtFlw2Arg3
+            // 
+            this.txtFlw2Arg3.Location = new System.Drawing.Point(178, 190);
+            this.txtFlw2Arg3.MaxLength = 4;
+            this.txtFlw2Arg3.Name = "txtFlw2Arg3";
+            this.txtFlw2Arg3.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2Arg3.TabIndex = 6;
+            this.txtFlw2Arg3.TextChanged += new System.EventHandler(this.TxtFlw2Arg3_TextChanged);
+            this.txtFlw2Arg3.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2BranchTrue_KeyPress);
+            // 
+            // txtFlw2Arg2
+            // 
+            this.txtFlw2Arg2.Location = new System.Drawing.Point(178, 165);
+            this.txtFlw2Arg2.MaxLength = 4;
+            this.txtFlw2Arg2.Name = "txtFlw2Arg2";
+            this.txtFlw2Arg2.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2Arg2.TabIndex = 5;
+            this.txtFlw2Arg2.TextChanged += new System.EventHandler(this.TxtFlw2Arg2_TextChanged);
+            this.txtFlw2Arg2.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2BranchTrue_KeyPress);
+            // 
+            // txtFlw2Arg1
+            // 
+            this.txtFlw2Arg1.Location = new System.Drawing.Point(178, 140);
+            this.txtFlw2Arg1.MaxLength = 4;
+            this.txtFlw2Arg1.Name = "txtFlw2Arg1";
+            this.txtFlw2Arg1.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2Arg1.TabIndex = 4;
+            this.txtFlw2Arg1.TextChanged += new System.EventHandler(this.TxtFlw2Arg1_TextChanged);
+            this.txtFlw2Arg1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2BranchTrue_KeyPress);
+            // 
+            // txtFlw2Padding
+            // 
+            this.txtFlw2Padding.Location = new System.Drawing.Point(178, 115);
+            this.txtFlw2Padding.MaxLength = 4;
+            this.txtFlw2Padding.Name = "txtFlw2Padding";
+            this.txtFlw2Padding.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2Padding.TabIndex = 3;
+            this.txtFlw2Padding.TextChanged += new System.EventHandler(this.TxtFlw2Padding_TextChanged);
+            this.txtFlw2Padding.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2BranchTrue_KeyPress);
+            // 
+            // lblFlw2Padding
+            // 
+            this.lblFlw2Padding.AutoSize = true;
+            this.lblFlw2Padding.Location = new System.Drawing.Point(6, 118);
+            this.lblFlw2Padding.Name = "lblFlw2Padding";
+            this.lblFlw2Padding.Size = new System.Drawing.Size(62, 12);
+            this.lblFlw2Padding.TabIndex = 2;
+            this.lblFlw2Padding.Text = "パディング？";
+            // 
+            // txtFlw2FlowType
+            // 
+            this.txtFlw2FlowType.Location = new System.Drawing.Point(178, 12);
+            this.txtFlw2FlowType.MaxLength = 4;
+            this.txtFlw2FlowType.Name = "txtFlw2FlowType";
+            this.txtFlw2FlowType.Size = new System.Drawing.Size(100, 19);
+            this.txtFlw2FlowType.TabIndex = 1;
+            this.txtFlw2FlowType.TextChanged += new System.EventHandler(this.TxtFlw2FlowType_TextChanged);
+            this.txtFlw2FlowType.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtFlw2FlowType_KeyPress);
+            // 
+            // lblFlw2FlowType
+            // 
+            this.lblFlw2FlowType.AutoSize = true;
+            this.lblFlw2FlowType.Location = new System.Drawing.Point(6, 15);
+            this.lblFlw2FlowType.Name = "lblFlw2FlowType";
+            this.lblFlw2FlowType.Size = new System.Drawing.Size(58, 12);
+            this.lblFlw2FlowType.TabIndex = 0;
+            this.lblFlw2FlowType.Text = "フロータイプ";
+            // 
+            // tbpDebugMsbf
+            // 
+            this.tbpDebugMsbf.Controls.Add(this.lblMsbfHashCalculator);
+            this.tbpDebugMsbf.Controls.Add(this.textBox34);
+            this.tbpDebugMsbf.Controls.Add(this.button30);
+            this.tbpDebugMsbf.Controls.Add(this.textBox33);
+            this.tbpDebugMsbf.Controls.Add(this.textBox32);
+            this.tbpDebugMsbf.Controls.Add(this.btnCalculateHash);
+            this.tbpDebugMsbf.Controls.Add(this.txtListNameToCalculateHash);
+            this.tbpDebugMsbf.Controls.Add(this.richTextBox1);
+            this.tbpDebugMsbf.Controls.Add(this.txtFlw2DebugHex);
+            this.tbpDebugMsbf.Location = new System.Drawing.Point(4, 22);
+            this.tbpDebugMsbf.Name = "tbpDebugMsbf";
+            this.tbpDebugMsbf.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpDebugMsbf.Size = new System.Drawing.Size(560, 434);
+            this.tbpDebugMsbf.TabIndex = 4;
+            this.tbpDebugMsbf.Text = "MSBFデバッグ";
+            this.tbpDebugMsbf.UseVisualStyleBackColor = true;
+            // 
+            // lblMsbfHashCalculator
+            // 
+            this.lblMsbfHashCalculator.AutoSize = true;
+            this.lblMsbfHashCalculator.Location = new System.Drawing.Point(6, 12);
+            this.lblMsbfHashCalculator.Name = "lblMsbfHashCalculator";
+            this.lblMsbfHashCalculator.Size = new System.Drawing.Size(107, 12);
+            this.lblMsbfHashCalculator.TabIndex = 16;
+            this.lblMsbfHashCalculator.Text = "MSBFハッシュ計算機";
+            this.lblMsbfHashCalculator.Click += new System.EventHandler(this.LblMsbfHashCalculator_Click);
             // 
             // textBox34
             // 
@@ -1973,20 +1973,20 @@ namespace MSBT_Editor
             this.richTextBox1.Text = "";
             this.richTextBox1.Visible = false;
             // 
-            // textBox13
+            // txtFlw2DebugHex
             // 
-            this.textBox13.Location = new System.Drawing.Point(6, 112);
-            this.textBox13.Multiline = true;
-            this.textBox13.Name = "textBox13";
-            this.textBox13.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBox13.Size = new System.Drawing.Size(548, 66);
-            this.textBox13.TabIndex = 7;
+            this.txtFlw2DebugHex.Location = new System.Drawing.Point(6, 112);
+            this.txtFlw2DebugHex.Multiline = true;
+            this.txtFlw2DebugHex.Name = "txtFlw2DebugHex";
+            this.txtFlw2DebugHex.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtFlw2DebugHex.Size = new System.Drawing.Size(548, 66);
+            this.txtFlw2DebugHex.TabIndex = 7;
             // 
             // tbpDebug
             // 
             this.tbpDebug.Controls.Add(this.textBox1);
-            this.tbpDebug.Controls.Add(this.button1);
-            this.tbpDebug.Controls.Add(this.UnknownTag);
+            this.tbpDebug.Controls.Add(this.btnTextSort);
+            this.tbpDebug.Controls.Add(this.txtUnknownTag);
             this.tbpDebug.Controls.Add(this.MSBT_Debug_Text);
             this.tbpDebug.Controls.Add(this.textBox27);
             this.tbpDebug.Controls.Add(this.btnReleaseDebugTextFile);
@@ -2007,24 +2007,24 @@ namespace MSBT_Editor
             this.textBox1.TabIndex = 16;
             this.textBox1.Visible = false;
             // 
-            // button1
+            // btnTextSort
             // 
-            this.button1.Location = new System.Drawing.Point(345, 393);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(209, 35);
-            this.button1.TabIndex = 15;
-            this.button1.Text = "TextSort";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.btnTextSort.Location = new System.Drawing.Point(345, 393);
+            this.btnTextSort.Name = "btnTextSort";
+            this.btnTextSort.Size = new System.Drawing.Size(209, 35);
+            this.btnTextSort.TabIndex = 15;
+            this.btnTextSort.Text = "TextSort";
+            this.btnTextSort.UseVisualStyleBackColor = true;
+            this.btnTextSort.Click += new System.EventHandler(this.BtnTextSort_Click);
             // 
-            // UnknownTag
+            // txtUnknownTag
             // 
-            this.UnknownTag.Location = new System.Drawing.Point(6, 265);
-            this.UnknownTag.Multiline = true;
-            this.UnknownTag.Name = "UnknownTag";
-            this.UnknownTag.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.UnknownTag.Size = new System.Drawing.Size(548, 122);
-            this.UnknownTag.TabIndex = 14;
+            this.txtUnknownTag.Location = new System.Drawing.Point(6, 265);
+            this.txtUnknownTag.Multiline = true;
+            this.txtUnknownTag.Name = "txtUnknownTag";
+            this.txtUnknownTag.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.txtUnknownTag.Size = new System.Drawing.Size(548, 122);
+            this.txtUnknownTag.TabIndex = 14;
             // 
             // MSBT_Debug_Text
             // 
@@ -2055,10 +2055,10 @@ namespace MSBT_Editor
             // 
             // tbpCredit
             // 
-            this.tbpCredit.Controls.Add(this.gbxCreditLBL1);
-            this.tbpCredit.Controls.Add(this.txtATR1SpecialTextOffset);
+            this.tbpCredit.Controls.Add(this.gbxCreditLbl1);
+            this.tbpCredit.Controls.Add(this.txtAtr1SpecialTextOffset);
             this.tbpCredit.Controls.Add(this.gbxCreditProgrammer);
-            this.tbpCredit.Controls.Add(this.lblATR1SpecialTextOffset);
+            this.tbpCredit.Controls.Add(this.lblAtr1SpecialTextOffset);
             this.tbpCredit.Controls.Add(this.gbxCreditDebugger);
             this.tbpCredit.Controls.Add(this.gbxCreditSectionEntrySize);
             this.tbpCredit.Location = new System.Drawing.Point(4, 22);
@@ -2069,60 +2069,60 @@ namespace MSBT_Editor
             this.tbpCredit.Text = "Credit";
             this.tbpCredit.UseVisualStyleBackColor = true;
             // 
-            // gbxCreditLBL1
+            // gbxCreditLbl1
             // 
-            this.gbxCreditLBL1.Controls.Add(this.lblCreditLBL1Note);
-            this.gbxCreditLBL1.Controls.Add(this.lblLBL1TagIndex);
-            this.gbxCreditLBL1.Controls.Add(this.txtLBL1TagIndex);
-            this.gbxCreditLBL1.Location = new System.Drawing.Point(283, 337);
-            this.gbxCreditLBL1.Name = "gbxCreditLBL1";
-            this.gbxCreditLBL1.Size = new System.Drawing.Size(233, 91);
-            this.gbxCreditLBL1.TabIndex = 7;
-            this.gbxCreditLBL1.TabStop = false;
-            this.gbxCreditLBL1.Text = "LBL1";
-            this.gbxCreditLBL1.Visible = false;
+            this.gbxCreditLbl1.Controls.Add(this.lblCreditLbl1Note);
+            this.gbxCreditLbl1.Controls.Add(this.lblLbl1TagIndex);
+            this.gbxCreditLbl1.Controls.Add(this.txtLbl1TagIndex);
+            this.gbxCreditLbl1.Location = new System.Drawing.Point(283, 337);
+            this.gbxCreditLbl1.Name = "gbxCreditLbl1";
+            this.gbxCreditLbl1.Size = new System.Drawing.Size(233, 91);
+            this.gbxCreditLbl1.TabIndex = 7;
+            this.gbxCreditLbl1.TabStop = false;
+            this.gbxCreditLbl1.Text = "LBL1";
+            this.gbxCreditLbl1.Visible = false;
             // 
-            // lblCreditLBL1Note
+            // lblCreditLbl1Note
             // 
-            this.lblCreditLBL1Note.AutoSize = true;
-            this.lblCreditLBL1Note.ForeColor = System.Drawing.Color.Red;
-            this.lblCreditLBL1Note.Location = new System.Drawing.Point(6, 13);
-            this.lblCreditLBL1Note.Name = "lblCreditLBL1Note";
-            this.lblCreditLBL1Note.Size = new System.Drawing.Size(162, 24);
-            this.lblCreditLBL1Note.TabIndex = 7;
-            this.lblCreditLBL1Note.Text = "この項目が　0　の場合\r\nゲームにテキストが認識されません";
+            this.lblCreditLbl1Note.AutoSize = true;
+            this.lblCreditLbl1Note.ForeColor = System.Drawing.Color.Red;
+            this.lblCreditLbl1Note.Location = new System.Drawing.Point(6, 13);
+            this.lblCreditLbl1Note.Name = "lblCreditLbl1Note";
+            this.lblCreditLbl1Note.Size = new System.Drawing.Size(162, 24);
+            this.lblCreditLbl1Note.TabIndex = 7;
+            this.lblCreditLbl1Note.Text = "この項目が　0　の場合\r\nゲームにテキストが認識されません";
             // 
-            // lblLBL1TagIndex
+            // lblLbl1TagIndex
             // 
-            this.lblLBL1TagIndex.AutoSize = true;
-            this.lblLBL1TagIndex.Location = new System.Drawing.Point(6, 47);
-            this.lblLBL1TagIndex.Name = "lblLBL1TagIndex";
-            this.lblLBL1TagIndex.Size = new System.Drawing.Size(86, 12);
-            this.lblLBL1TagIndex.TabIndex = 6;
-            this.lblLBL1TagIndex.Text = "タグインデックス？";
+            this.lblLbl1TagIndex.AutoSize = true;
+            this.lblLbl1TagIndex.Location = new System.Drawing.Point(6, 47);
+            this.lblLbl1TagIndex.Name = "lblLbl1TagIndex";
+            this.lblLbl1TagIndex.Size = new System.Drawing.Size(86, 12);
+            this.lblLbl1TagIndex.TabIndex = 6;
+            this.lblLbl1TagIndex.Text = "タグインデックス？";
             // 
-            // txtLBL1TagIndex
+            // txtLbl1TagIndex
             // 
-            this.txtLBL1TagIndex.Enabled = false;
-            this.txtLBL1TagIndex.Location = new System.Drawing.Point(127, 44);
-            this.txtLBL1TagIndex.Name = "txtLBL1TagIndex";
-            this.txtLBL1TagIndex.Size = new System.Drawing.Size(100, 19);
-            this.txtLBL1TagIndex.TabIndex = 5;
-            this.txtLBL1TagIndex.TextChanged += new System.EventHandler(this.TxtLBL1TagIndex_TextChanged);
+            this.txtLbl1TagIndex.Enabled = false;
+            this.txtLbl1TagIndex.Location = new System.Drawing.Point(127, 44);
+            this.txtLbl1TagIndex.Name = "txtLbl1TagIndex";
+            this.txtLbl1TagIndex.Size = new System.Drawing.Size(100, 19);
+            this.txtLbl1TagIndex.TabIndex = 5;
+            this.txtLbl1TagIndex.TextChanged += new System.EventHandler(this.TxtLbl1TagIndex_TextChanged);
             // 
-            // txtATR1SpecialTextOffset
+            // txtAtr1SpecialTextOffset
             // 
-            this.txtATR1SpecialTextOffset.Enabled = false;
-            this.txtATR1SpecialTextOffset.Location = new System.Drawing.Point(133, 294);
-            this.txtATR1SpecialTextOffset.MaxLength = 2;
-            this.txtATR1SpecialTextOffset.Name = "txtATR1SpecialTextOffset";
-            this.txtATR1SpecialTextOffset.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1SpecialTextOffset.TabIndex = 7;
-            this.txtATR1SpecialTextOffset.Visible = false;
+            this.txtAtr1SpecialTextOffset.Enabled = false;
+            this.txtAtr1SpecialTextOffset.Location = new System.Drawing.Point(133, 294);
+            this.txtAtr1SpecialTextOffset.MaxLength = 2;
+            this.txtAtr1SpecialTextOffset.Name = "txtAtr1SpecialTextOffset";
+            this.txtAtr1SpecialTextOffset.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1SpecialTextOffset.TabIndex = 7;
+            this.txtAtr1SpecialTextOffset.Visible = false;
             // 
             // gbxCreditProgrammer
             // 
-            this.gbxCreditProgrammer.Controls.Add(this.label54);
+            this.gbxCreditProgrammer.Controls.Add(this.lblCreditContributorAcknowledgment);
             this.gbxCreditProgrammer.Controls.Add(this.gbxCreditContributor);
             this.gbxCreditProgrammer.Controls.Add(this.lblCreditPenguin);
             this.gbxCreditProgrammer.Location = new System.Drawing.Point(6, 6);
@@ -2132,14 +2132,14 @@ namespace MSBT_Editor
             this.gbxCreditProgrammer.TabStop = false;
             this.gbxCreditProgrammer.Text = "プログラミングとその他全般";
             // 
-            // label54
+            // lblCreditContributorAcknowledgment
             // 
-            this.label54.AutoSize = true;
-            this.label54.Location = new System.Drawing.Point(10, 69);
-            this.label54.Name = "label54";
-            this.label54.Size = new System.Drawing.Size(177, 24);
-            this.label54.TabIndex = 5;
-            this.label54.Text = "ツールの完成に協力して下さった\r\nEvanbowlさんありがとうございました。";
+            this.lblCreditContributorAcknowledgment.AutoSize = true;
+            this.lblCreditContributorAcknowledgment.Location = new System.Drawing.Point(10, 69);
+            this.lblCreditContributorAcknowledgment.Name = "lblCreditContributorAcknowledgment";
+            this.lblCreditContributorAcknowledgment.Size = new System.Drawing.Size(177, 24);
+            this.lblCreditContributorAcknowledgment.TabIndex = 5;
+            this.lblCreditContributorAcknowledgment.Text = "ツールの完成に協力して下さった\r\nEvanbowlさんありがとうございました。";
             // 
             // gbxCreditContributor
             // 
@@ -2169,19 +2169,19 @@ namespace MSBT_Editor
             this.lblCreditPenguin.TabIndex = 0;
             this.lblCreditPenguin.Text = "ぺんぐいん";
             // 
-            // lblATR1SpecialTextOffset
+            // lblAtr1SpecialTextOffset
             // 
-            this.lblATR1SpecialTextOffset.AutoSize = true;
-            this.lblATR1SpecialTextOffset.Location = new System.Drawing.Point(22, 297);
-            this.lblATR1SpecialTextOffset.Name = "lblATR1SpecialTextOffset";
-            this.lblATR1SpecialTextOffset.Size = new System.Drawing.Size(105, 12);
-            this.lblATR1SpecialTextOffset.TabIndex = 15;
-            this.lblATR1SpecialTextOffset.Text = "nullオフセット触らない";
-            this.lblATR1SpecialTextOffset.Visible = false;
+            this.lblAtr1SpecialTextOffset.AutoSize = true;
+            this.lblAtr1SpecialTextOffset.Location = new System.Drawing.Point(22, 297);
+            this.lblAtr1SpecialTextOffset.Name = "lblAtr1SpecialTextOffset";
+            this.lblAtr1SpecialTextOffset.Size = new System.Drawing.Size(105, 12);
+            this.lblAtr1SpecialTextOffset.TabIndex = 15;
+            this.lblAtr1SpecialTextOffset.Text = "nullオフセット触らない";
+            this.lblAtr1SpecialTextOffset.Visible = false;
             // 
             // gbxCreditDebugger
             // 
-            this.gbxCreditDebugger.Controls.Add(this.label55);
+            this.gbxCreditDebugger.Controls.Add(this.lblDebuggerAcknowledgment);
             this.gbxCreditDebugger.Controls.Add(this.gbxCreditDebuggerVIP);
             this.gbxCreditDebugger.Controls.Add(this.lblCreditPorto);
             this.gbxCreditDebugger.Controls.Add(this.lblCreditHiiraghi);
@@ -2193,14 +2193,14 @@ namespace MSBT_Editor
             this.gbxCreditDebugger.TabStop = false;
             this.gbxCreditDebugger.Text = "デバッガー";
             // 
-            // label55
+            // lblDebuggerAcknowledgment
             // 
-            this.label55.AutoSize = true;
-            this.label55.Location = new System.Drawing.Point(10, 89);
-            this.label55.Name = "label55";
-            this.label55.Size = new System.Drawing.Size(149, 24);
-            this.label55.TabIndex = 2;
-            this.label55.Text = "デバッガーの皆様もご協力頂き\r\nありがとうございました。";
+            this.lblDebuggerAcknowledgment.AutoSize = true;
+            this.lblDebuggerAcknowledgment.Location = new System.Drawing.Point(10, 89);
+            this.lblDebuggerAcknowledgment.Name = "lblDebuggerAcknowledgment";
+            this.lblDebuggerAcknowledgment.Size = new System.Drawing.Size(149, 24);
+            this.lblDebuggerAcknowledgment.TabIndex = 2;
+            this.lblDebuggerAcknowledgment.Text = "デバッガーの皆様もご協力頂き\r\nありがとうございました。";
             // 
             // gbxCreditDebuggerVIP
             // 
@@ -2260,11 +2260,11 @@ namespace MSBT_Editor
             // 
             // gbxCreditSectionEntrySize
             // 
-            this.gbxCreditSectionEntrySize.Controls.Add(this.txtATR1EntrySize);
-            this.gbxCreditSectionEntrySize.Controls.Add(this.lblATR1EntrySize);
-            this.gbxCreditSectionEntrySize.Controls.Add(this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote);
-            this.gbxCreditSectionEntrySize.Controls.Add(this.txtLBL1EntrySize);
-            this.gbxCreditSectionEntrySize.Controls.Add(this.lblLBL1EntrySize);
+            this.gbxCreditSectionEntrySize.Controls.Add(this.txtAtr1EntrySize);
+            this.gbxCreditSectionEntrySize.Controls.Add(this.lblAtr1EntrySize);
+            this.gbxCreditSectionEntrySize.Controls.Add(this.lblCreditSectionEntrySize);
+            this.gbxCreditSectionEntrySize.Controls.Add(this.txtLbl1EntrySize);
+            this.gbxCreditSectionEntrySize.Controls.Add(this.lblLbl1EntrySize);
             this.gbxCreditSectionEntrySize.Location = new System.Drawing.Point(14, 331);
             this.gbxCreditSectionEntrySize.Name = "gbxCreditSectionEntrySize";
             this.gbxCreditSectionEntrySize.Size = new System.Drawing.Size(263, 91);
@@ -2273,62 +2273,62 @@ namespace MSBT_Editor
             this.gbxCreditSectionEntrySize.Text = "各セクションのエントリーサイズ";
             this.gbxCreditSectionEntrySize.Visible = false;
             // 
-            // txtATR1EntrySize
+            // txtAtr1EntrySize
             // 
-            this.txtATR1EntrySize.Enabled = false;
-            this.txtATR1EntrySize.Location = new System.Drawing.Point(147, 68);
-            this.txtATR1EntrySize.Name = "txtATR1EntrySize";
-            this.txtATR1EntrySize.Size = new System.Drawing.Size(100, 19);
-            this.txtATR1EntrySize.TabIndex = 3;
-            this.txtATR1EntrySize.TextChanged += new System.EventHandler(this.TxtATR1EntrySize_TextChanged);
+            this.txtAtr1EntrySize.Enabled = false;
+            this.txtAtr1EntrySize.Location = new System.Drawing.Point(147, 68);
+            this.txtAtr1EntrySize.Name = "txtAtr1EntrySize";
+            this.txtAtr1EntrySize.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1EntrySize.TabIndex = 3;
+            this.txtAtr1EntrySize.TextChanged += new System.EventHandler(this.TxtAtr1EntrySize_TextChanged);
             // 
-            // lblATR1EntrySize
+            // lblAtr1EntrySize
             // 
-            this.lblATR1EntrySize.AutoSize = true;
-            this.lblATR1EntrySize.Location = new System.Drawing.Point(6, 71);
-            this.lblATR1EntrySize.Name = "lblATR1EntrySize";
-            this.lblATR1EntrySize.Size = new System.Drawing.Size(34, 12);
-            this.lblATR1EntrySize.TabIndex = 2;
-            this.lblATR1EntrySize.Text = "ATR1";
+            this.lblAtr1EntrySize.AutoSize = true;
+            this.lblAtr1EntrySize.Location = new System.Drawing.Point(6, 71);
+            this.lblAtr1EntrySize.Name = "lblAtr1EntrySize";
+            this.lblAtr1EntrySize.Size = new System.Drawing.Size(34, 12);
+            this.lblAtr1EntrySize.TabIndex = 2;
+            this.lblAtr1EntrySize.Text = "ATR1";
             // 
-            // lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote
+            // lblCreditSectionEntrySize
             // 
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote.AutoSize = true;
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote.ForeColor = System.Drawing.Color.Red;
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote.Location = new System.Drawing.Point(6, 13);
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote.Name = "lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote";
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote.Size = new System.Drawing.Size(146, 24);
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote.TabIndex = 2;
-            this.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote.Text = "※初心者は触らないでください\r\nデータが破損する恐れあり";
+            this.lblCreditSectionEntrySize.AutoSize = true;
+            this.lblCreditSectionEntrySize.ForeColor = System.Drawing.Color.Red;
+            this.lblCreditSectionEntrySize.Location = new System.Drawing.Point(6, 13);
+            this.lblCreditSectionEntrySize.Name = "lblCreditSectionEntrySize";
+            this.lblCreditSectionEntrySize.Size = new System.Drawing.Size(146, 24);
+            this.lblCreditSectionEntrySize.TabIndex = 2;
+            this.lblCreditSectionEntrySize.Text = "※初心者は触らないでください\r\nデータが破損する恐れあり";
             // 
-            // txtLBL1EntrySize
+            // txtLbl1EntrySize
             // 
-            this.txtLBL1EntrySize.Enabled = false;
-            this.txtLBL1EntrySize.Location = new System.Drawing.Point(147, 44);
-            this.txtLBL1EntrySize.Name = "txtLBL1EntrySize";
-            this.txtLBL1EntrySize.Size = new System.Drawing.Size(100, 19);
-            this.txtLBL1EntrySize.TabIndex = 1;
-            this.txtLBL1EntrySize.TextChanged += new System.EventHandler(this.TxtLBL1EntrySize_TextChanged);
+            this.txtLbl1EntrySize.Enabled = false;
+            this.txtLbl1EntrySize.Location = new System.Drawing.Point(147, 44);
+            this.txtLbl1EntrySize.Name = "txtLbl1EntrySize";
+            this.txtLbl1EntrySize.Size = new System.Drawing.Size(100, 19);
+            this.txtLbl1EntrySize.TabIndex = 1;
+            this.txtLbl1EntrySize.TextChanged += new System.EventHandler(this.TxtLbl1EntrySize_TextChanged);
             // 
-            // lblLBL1EntrySize
+            // lblLbl1EntrySize
             // 
-            this.lblLBL1EntrySize.AutoSize = true;
-            this.lblLBL1EntrySize.Location = new System.Drawing.Point(6, 47);
-            this.lblLBL1EntrySize.Name = "lblLBL1EntrySize";
-            this.lblLBL1EntrySize.Size = new System.Drawing.Size(31, 12);
-            this.lblLBL1EntrySize.TabIndex = 0;
-            this.lblLBL1EntrySize.Text = "LBL1";
+            this.lblLbl1EntrySize.AutoSize = true;
+            this.lblLbl1EntrySize.Location = new System.Drawing.Point(6, 47);
+            this.lblLbl1EntrySize.Name = "lblLbl1EntrySize";
+            this.lblLbl1EntrySize.Size = new System.Drawing.Size(31, 12);
+            this.lblLbl1EntrySize.TabIndex = 0;
+            this.lblLbl1EntrySize.Text = "LBL1";
             // 
             // tbpInfomation
             // 
             this.tbpInfomation.Controls.Add(this.gbxCurrentVersion);
-            this.tbpInfomation.Controls.Add(this.lblGitHubReleasesURL);
+            this.tbpInfomation.Controls.Add(this.lblGitHubReleasesUrl);
             this.tbpInfomation.Controls.Add(this.gbxHowToUse);
-            this.tbpInfomation.Controls.Add(this.lblGitHubIssuesURL);
-            this.tbpInfomation.Controls.Add(this.llbGitHubRepositoryURL);
-            this.tbpInfomation.Controls.Add(this.llbGitHubReleasesURL);
-            this.tbpInfomation.Controls.Add(this.lblGitHubRepositoryURL);
-            this.tbpInfomation.Controls.Add(this.llbGitHubIssuesURL);
+            this.tbpInfomation.Controls.Add(this.lblGitHubIssuesUrl);
+            this.tbpInfomation.Controls.Add(this.llbGitHubRepositoryUrl);
+            this.tbpInfomation.Controls.Add(this.llbGitHubReleasesUrl);
+            this.tbpInfomation.Controls.Add(this.lblGitHubRepositoryUrl);
+            this.tbpInfomation.Controls.Add(this.llbGitHubIssuesUrl);
             this.tbpInfomation.Location = new System.Drawing.Point(4, 22);
             this.tbpInfomation.Name = "tbpInfomation";
             this.tbpInfomation.Padding = new System.Windows.Forms.Padding(3);
@@ -2358,21 +2358,21 @@ namespace MSBT_Editor
             this.lblCurrentVersion.TabIndex = 8;
             this.lblCurrentVersion.Text = "ver";
             // 
-            // lblGitHubReleasesURL
+            // lblGitHubReleasesUrl
             // 
-            this.lblGitHubReleasesURL.AutoSize = true;
-            this.lblGitHubReleasesURL.Location = new System.Drawing.Point(16, 62);
-            this.lblGitHubReleasesURL.Name = "lblGitHubReleasesURL";
-            this.lblGitHubReleasesURL.Size = new System.Drawing.Size(215, 12);
-            this.lblGitHubReleasesURL.TabIndex = 1;
-            this.lblGitHubReleasesURL.Text = "このツールの最新版はこちらからお探しください";
+            this.lblGitHubReleasesUrl.AutoSize = true;
+            this.lblGitHubReleasesUrl.Location = new System.Drawing.Point(16, 62);
+            this.lblGitHubReleasesUrl.Name = "lblGitHubReleasesUrl";
+            this.lblGitHubReleasesUrl.Size = new System.Drawing.Size(215, 12);
+            this.lblGitHubReleasesUrl.TabIndex = 1;
+            this.lblGitHubReleasesUrl.Text = "このツールの最新版はこちらからお探しください";
             // 
             // gbxHowToUse
             // 
-            this.gbxHowToUse.Controls.Add(this.lblSMG2HackWikiURL);
-            this.gbxHowToUse.Controls.Add(this.llbSMG2HackWikiURL);
-            this.gbxHowToUse.Controls.Add(this.lblSMG2HackDiscordURL);
-            this.gbxHowToUse.Controls.Add(this.llbSMG2HackDiscordURL);
+            this.gbxHowToUse.Controls.Add(this.lblSMG2HackWikiUrl);
+            this.gbxHowToUse.Controls.Add(this.llbSMG2HackWikiUrl);
+            this.gbxHowToUse.Controls.Add(this.lblSMG2HackDiscordUrl);
+            this.gbxHowToUse.Controls.Add(this.llbSMG2HackDiscordUrl);
             this.gbxHowToUse.Location = new System.Drawing.Point(6, 154);
             this.gbxHowToUse.Name = "gbxHowToUse";
             this.gbxHowToUse.Size = new System.Drawing.Size(313, 85);
@@ -2380,145 +2380,145 @@ namespace MSBT_Editor
             this.gbxHowToUse.TabStop = false;
             this.gbxHowToUse.Text = "ツールの使い方が分からない場合はこちらを参照してください";
             // 
-            // lblSMG2HackWikiURL
+            // lblSMG2HackWikiUrl
             // 
-            this.lblSMG2HackWikiURL.AutoSize = true;
-            this.lblSMG2HackWikiURL.Location = new System.Drawing.Point(10, 15);
-            this.lblSMG2HackWikiURL.Name = "lblSMG2HackWikiURL";
-            this.lblSMG2HackWikiURL.Size = new System.Drawing.Size(25, 12);
-            this.lblSMG2HackWikiURL.TabIndex = 19;
-            this.lblSMG2HackWikiURL.Text = "wiki";
+            this.lblSMG2HackWikiUrl.AutoSize = true;
+            this.lblSMG2HackWikiUrl.Location = new System.Drawing.Point(10, 15);
+            this.lblSMG2HackWikiUrl.Name = "lblSMG2HackWikiUrl";
+            this.lblSMG2HackWikiUrl.Size = new System.Drawing.Size(25, 12);
+            this.lblSMG2HackWikiUrl.TabIndex = 19;
+            this.lblSMG2HackWikiUrl.Text = "wiki";
             // 
-            // llbSMG2HackWikiURL
+            // llbSMG2HackWikiUrl
             // 
-            this.llbSMG2HackWikiURL.AutoSize = true;
-            this.llbSMG2HackWikiURL.Location = new System.Drawing.Point(10, 27);
-            this.llbSMG2HackWikiURL.Name = "llbSMG2HackWikiURL";
-            this.llbSMG2HackWikiURL.Size = new System.Drawing.Size(290, 12);
-            this.llbSMG2HackWikiURL.TabIndex = 18;
-            this.llbSMG2HackWikiURL.TabStop = true;
-            this.llbSMG2HackWikiURL.Text = "http://mariogalaxy2hack.wiki.fc2.com/wiki/MSBT_Editor";
-            this.llbSMG2HackWikiURL.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbSMG2HackWikiURL_LinkClicked);
+            this.llbSMG2HackWikiUrl.AutoSize = true;
+            this.llbSMG2HackWikiUrl.Location = new System.Drawing.Point(10, 27);
+            this.llbSMG2HackWikiUrl.Name = "llbSMG2HackWikiUrl";
+            this.llbSMG2HackWikiUrl.Size = new System.Drawing.Size(290, 12);
+            this.llbSMG2HackWikiUrl.TabIndex = 18;
+            this.llbSMG2HackWikiUrl.TabStop = true;
+            this.llbSMG2HackWikiUrl.Text = "http://mariogalaxy2hack.wiki.fc2.com/wiki/MSBT_Editor";
+            this.llbSMG2HackWikiUrl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbSMG2HackWikiUrl_LinkClicked);
             // 
-            // lblSMG2HackDiscordURL
+            // lblSMG2HackDiscordUrl
             // 
-            this.lblSMG2HackDiscordURL.AutoSize = true;
-            this.lblSMG2HackDiscordURL.Location = new System.Drawing.Point(10, 49);
-            this.lblSMG2HackDiscordURL.Name = "lblSMG2HackDiscordURL";
-            this.lblSMG2HackDiscordURL.Size = new System.Drawing.Size(90, 12);
-            this.lblSMG2HackDiscordURL.TabIndex = 17;
-            this.lblSMG2HackDiscordURL.Text = "Discord招待URL";
+            this.lblSMG2HackDiscordUrl.AutoSize = true;
+            this.lblSMG2HackDiscordUrl.Location = new System.Drawing.Point(10, 49);
+            this.lblSMG2HackDiscordUrl.Name = "lblSMG2HackDiscordUrl";
+            this.lblSMG2HackDiscordUrl.Size = new System.Drawing.Size(90, 12);
+            this.lblSMG2HackDiscordUrl.TabIndex = 17;
+            this.lblSMG2HackDiscordUrl.Text = "Discord招待URL";
             // 
-            // llbSMG2HackDiscordURL
+            // llbSMG2HackDiscordUrl
             // 
-            this.llbSMG2HackDiscordURL.AutoSize = true;
-            this.llbSMG2HackDiscordURL.Location = new System.Drawing.Point(10, 61);
-            this.llbSMG2HackDiscordURL.Name = "llbSMG2HackDiscordURL";
-            this.llbSMG2HackDiscordURL.Size = new System.Drawing.Size(150, 12);
-            this.llbSMG2HackDiscordURL.TabIndex = 16;
-            this.llbSMG2HackDiscordURL.TabStop = true;
-            this.llbSMG2HackDiscordURL.Text = "https://discord.gg/B4EwY7h";
-            this.llbSMG2HackDiscordURL.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbSMG2HackDiscordURL_LinkClicked);
+            this.llbSMG2HackDiscordUrl.AutoSize = true;
+            this.llbSMG2HackDiscordUrl.Location = new System.Drawing.Point(10, 61);
+            this.llbSMG2HackDiscordUrl.Name = "llbSMG2HackDiscordUrl";
+            this.llbSMG2HackDiscordUrl.Size = new System.Drawing.Size(150, 12);
+            this.llbSMG2HackDiscordUrl.TabIndex = 16;
+            this.llbSMG2HackDiscordUrl.TabStop = true;
+            this.llbSMG2HackDiscordUrl.Text = "https://discord.gg/B4EwY7h";
+            this.llbSMG2HackDiscordUrl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbSMG2HackDiscordUrl_LinkClicked);
             // 
-            // lblGitHubIssuesURL
+            // lblGitHubIssuesUrl
             // 
-            this.lblGitHubIssuesURL.AutoSize = true;
-            this.lblGitHubIssuesURL.Location = new System.Drawing.Point(16, 125);
-            this.lblGitHubIssuesURL.Name = "lblGitHubIssuesURL";
-            this.lblGitHubIssuesURL.Size = new System.Drawing.Size(83, 12);
-            this.lblGitHubIssuesURL.TabIndex = 5;
-            this.lblGitHubIssuesURL.Text = "バグ報告はこちら";
+            this.lblGitHubIssuesUrl.AutoSize = true;
+            this.lblGitHubIssuesUrl.Location = new System.Drawing.Point(16, 125);
+            this.lblGitHubIssuesUrl.Name = "lblGitHubIssuesUrl";
+            this.lblGitHubIssuesUrl.Size = new System.Drawing.Size(83, 12);
+            this.lblGitHubIssuesUrl.TabIndex = 5;
+            this.lblGitHubIssuesUrl.Text = "バグ報告はこちら";
             // 
-            // llbGitHubRepositoryURL
+            // llbGitHubRepositoryUrl
             // 
-            this.llbGitHubRepositoryURL.AutoSize = true;
-            this.llbGitHubRepositoryURL.Location = new System.Drawing.Point(16, 104);
-            this.llbGitHubRepositoryURL.Name = "llbGitHubRepositoryURL";
-            this.llbGitHubRepositoryURL.Size = new System.Drawing.Size(251, 12);
-            this.llbGitHubRepositoryURL.TabIndex = 2;
-            this.llbGitHubRepositoryURL.TabStop = true;
-            this.llbGitHubRepositoryURL.Text = "https://github.com/penguin117117/MSBT_Editor";
-            this.llbGitHubRepositoryURL.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbGitHubRepositoryURL_LinkClicked);
+            this.llbGitHubRepositoryUrl.AutoSize = true;
+            this.llbGitHubRepositoryUrl.Location = new System.Drawing.Point(16, 104);
+            this.llbGitHubRepositoryUrl.Name = "llbGitHubRepositoryUrl";
+            this.llbGitHubRepositoryUrl.Size = new System.Drawing.Size(251, 12);
+            this.llbGitHubRepositoryUrl.TabIndex = 2;
+            this.llbGitHubRepositoryUrl.TabStop = true;
+            this.llbGitHubRepositoryUrl.Text = "https://github.com/penguin117117/MSBT_Editor";
+            this.llbGitHubRepositoryUrl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbGitHubRepositoryUrl_LinkClicked);
             // 
-            // llbGitHubReleasesURL
+            // llbGitHubReleasesUrl
             // 
-            this.llbGitHubReleasesURL.AutoSize = true;
-            this.llbGitHubReleasesURL.Location = new System.Drawing.Point(16, 74);
-            this.llbGitHubReleasesURL.Name = "llbGitHubReleasesURL";
-            this.llbGitHubReleasesURL.Size = new System.Drawing.Size(300, 12);
-            this.llbGitHubReleasesURL.TabIndex = 0;
-            this.llbGitHubReleasesURL.TabStop = true;
-            this.llbGitHubReleasesURL.Text = "https://github.com/penguin117117/MSBT_Editor/releases";
-            this.llbGitHubReleasesURL.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbGitHubReleasesURL_LinkClicked);
+            this.llbGitHubReleasesUrl.AutoSize = true;
+            this.llbGitHubReleasesUrl.Location = new System.Drawing.Point(16, 74);
+            this.llbGitHubReleasesUrl.Name = "llbGitHubReleasesUrl";
+            this.llbGitHubReleasesUrl.Size = new System.Drawing.Size(300, 12);
+            this.llbGitHubReleasesUrl.TabIndex = 0;
+            this.llbGitHubReleasesUrl.TabStop = true;
+            this.llbGitHubReleasesUrl.Text = "https://github.com/penguin117117/MSBT_Editor/releases";
+            this.llbGitHubReleasesUrl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbGitHubReleasesUrl_LinkClicked);
             // 
-            // lblGitHubRepositoryURL
+            // lblGitHubRepositoryUrl
             // 
-            this.lblGitHubRepositoryURL.AutoSize = true;
-            this.lblGitHubRepositoryURL.Location = new System.Drawing.Point(16, 92);
-            this.lblGitHubRepositoryURL.Name = "lblGitHubRepositoryURL";
-            this.lblGitHubRepositoryURL.Size = new System.Drawing.Size(95, 12);
-            this.lblGitHubRepositoryURL.TabIndex = 3;
-            this.lblGitHubRepositoryURL.Text = "ソースコードはこちら";
+            this.lblGitHubRepositoryUrl.AutoSize = true;
+            this.lblGitHubRepositoryUrl.Location = new System.Drawing.Point(16, 92);
+            this.lblGitHubRepositoryUrl.Name = "lblGitHubRepositoryUrl";
+            this.lblGitHubRepositoryUrl.Size = new System.Drawing.Size(95, 12);
+            this.lblGitHubRepositoryUrl.TabIndex = 3;
+            this.lblGitHubRepositoryUrl.Text = "ソースコードはこちら";
             // 
-            // llbGitHubIssuesURL
+            // llbGitHubIssuesUrl
             // 
-            this.llbGitHubIssuesURL.AutoSize = true;
-            this.llbGitHubIssuesURL.Location = new System.Drawing.Point(16, 137);
-            this.llbGitHubIssuesURL.Name = "llbGitHubIssuesURL";
-            this.llbGitHubIssuesURL.Size = new System.Drawing.Size(290, 12);
-            this.llbGitHubIssuesURL.TabIndex = 4;
-            this.llbGitHubIssuesURL.TabStop = true;
-            this.llbGitHubIssuesURL.Text = "https://github.com/penguin117117/MSBT_Editor/issues";
-            this.llbGitHubIssuesURL.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbGitHubIssuesURL_LinkClicked);
+            this.llbGitHubIssuesUrl.AutoSize = true;
+            this.llbGitHubIssuesUrl.Location = new System.Drawing.Point(16, 137);
+            this.llbGitHubIssuesUrl.Name = "llbGitHubIssuesUrl";
+            this.llbGitHubIssuesUrl.Size = new System.Drawing.Size(290, 12);
+            this.llbGitHubIssuesUrl.TabIndex = 4;
+            this.llbGitHubIssuesUrl.TabStop = true;
+            this.llbGitHubIssuesUrl.Text = "https://github.com/penguin117117/MSBT_Editor/issues";
+            this.llbGitHubIssuesUrl.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LlbGitHubIssuesUrl_LinkClicked);
             // 
-            // lstListsInsideFEN1
+            // lstListsInsideFen1
             // 
-            this.lstListsInsideFEN1.FormattingEnabled = true;
-            this.lstListsInsideFEN1.ItemHeight = 12;
-            this.lstListsInsideFEN1.Location = new System.Drawing.Point(216, 243);
-            this.lstListsInsideFEN1.Name = "lstListsInsideFEN1";
-            this.lstListsInsideFEN1.ScrollAlwaysVisible = true;
-            this.lstListsInsideFEN1.Size = new System.Drawing.Size(204, 208);
-            this.lstListsInsideFEN1.TabIndex = 0;
-            this.lstListsInsideFEN1.SelectedIndexChanged += new System.EventHandler(this.LstListsInsideFEN1_SelectedIndexChanged);
+            this.lstListsInsideFen1.FormattingEnabled = true;
+            this.lstListsInsideFen1.ItemHeight = 12;
+            this.lstListsInsideFen1.Location = new System.Drawing.Point(216, 243);
+            this.lstListsInsideFen1.Name = "lstListsInsideFen1";
+            this.lstListsInsideFen1.ScrollAlwaysVisible = true;
+            this.lstListsInsideFen1.Size = new System.Drawing.Size(204, 208);
+            this.lstListsInsideFen1.TabIndex = 0;
+            this.lstListsInsideFen1.SelectedIndexChanged += new System.EventHandler(this.LstListsInsideFen1_SelectedIndexChanged);
             // 
-            // lstListsInsideFLW2
+            // lstListsInsideFlw2
             // 
-            this.lstListsInsideFLW2.FormattingEnabled = true;
-            this.lstListsInsideFLW2.ItemHeight = 12;
-            this.lstListsInsideFLW2.Location = new System.Drawing.Point(218, 27);
-            this.lstListsInsideFLW2.Name = "lstListsInsideFLW2";
-            this.lstListsInsideFLW2.ScrollAlwaysVisible = true;
-            this.lstListsInsideFLW2.Size = new System.Drawing.Size(204, 196);
-            this.lstListsInsideFLW2.TabIndex = 0;
-            this.lstListsInsideFLW2.SelectedIndexChanged += new System.EventHandler(this.LstListsInsideFLW2_SelectedIndexChanged);
+            this.lstListsInsideFlw2.FormattingEnabled = true;
+            this.lstListsInsideFlw2.ItemHeight = 12;
+            this.lstListsInsideFlw2.Location = new System.Drawing.Point(218, 27);
+            this.lstListsInsideFlw2.Name = "lstListsInsideFlw2";
+            this.lstListsInsideFlw2.ScrollAlwaysVisible = true;
+            this.lstListsInsideFlw2.Size = new System.Drawing.Size(204, 196);
+            this.lstListsInsideFlw2.TabIndex = 0;
+            this.lstListsInsideFlw2.SelectedIndexChanged += new System.EventHandler(this.LstListsInsideFlw2_SelectedIndexChanged);
             // 
-            // lblMSBT
+            // lblMsbt
             // 
-            this.lblMSBT.AutoSize = true;
-            this.lblMSBT.Location = new System.Drawing.Point(6, 14);
-            this.lblMSBT.Name = "lblMSBT";
-            this.lblMSBT.Size = new System.Drawing.Size(36, 12);
-            this.lblMSBT.TabIndex = 7;
-            this.lblMSBT.Text = "MSBT";
+            this.lblMsbt.AutoSize = true;
+            this.lblMsbt.Location = new System.Drawing.Point(6, 14);
+            this.lblMsbt.Name = "lblMsbt";
+            this.lblMsbt.Size = new System.Drawing.Size(36, 12);
+            this.lblMsbt.TabIndex = 7;
+            this.lblMsbt.Text = "MSBT";
             // 
-            // lblFLW2
+            // lblFlw2
             // 
-            this.lblFLW2.AutoSize = true;
-            this.lblFLW2.Location = new System.Drawing.Point(218, 14);
-            this.lblFLW2.Name = "lblFLW2";
-            this.lblFLW2.Size = new System.Drawing.Size(33, 12);
-            this.lblFLW2.TabIndex = 8;
-            this.lblFLW2.Text = "FLW2";
+            this.lblFlw2.AutoSize = true;
+            this.lblFlw2.Location = new System.Drawing.Point(218, 14);
+            this.lblFlw2.Name = "lblFlw2";
+            this.lblFlw2.Size = new System.Drawing.Size(33, 12);
+            this.lblFlw2.TabIndex = 8;
+            this.lblFlw2.Text = "FLW2";
             // 
-            // lblFEN1
+            // lblFen1
             // 
-            this.lblFEN1.AutoSize = true;
-            this.lblFEN1.Location = new System.Drawing.Point(218, 226);
-            this.lblFEN1.Name = "lblFEN1";
-            this.lblFEN1.Size = new System.Drawing.Size(33, 12);
-            this.lblFEN1.TabIndex = 9;
-            this.lblFEN1.Text = "FEN1";
+            this.lblFen1.AutoSize = true;
+            this.lblFen1.Location = new System.Drawing.Point(218, 226);
+            this.lblFen1.Name = "lblFen1";
+            this.lblFen1.Size = new System.Drawing.Size(33, 12);
+            this.lblFen1.TabIndex = 9;
+            this.lblFen1.Text = "FEN1";
             // 
             // cmbLanguage
             // 
@@ -2542,66 +2542,66 @@ namespace MSBT_Editor
             this.lblLanguage.TabIndex = 10;
             this.lblLanguage.Text = "Language";
             // 
-            // lblMSBTListSelectIndex
+            // lblMsbtListSelectIndex
             // 
-            this.lblMSBTListSelectIndex.AutoSize = true;
-            this.lblMSBTListSelectIndex.Location = new System.Drawing.Point(187, 14);
-            this.lblMSBTListSelectIndex.Name = "lblMSBTListSelectIndex";
-            this.lblMSBTListSelectIndex.Size = new System.Drawing.Size(23, 12);
-            this.lblMSBTListSelectIndex.TabIndex = 11;
-            this.lblMSBTListSelectIndex.Text = "null";
+            this.lblMsbtListSelectIndex.AutoSize = true;
+            this.lblMsbtListSelectIndex.Location = new System.Drawing.Point(187, 14);
+            this.lblMsbtListSelectIndex.Name = "lblMsbtListSelectIndex";
+            this.lblMsbtListSelectIndex.Size = new System.Drawing.Size(23, 12);
+            this.lblMsbtListSelectIndex.TabIndex = 11;
+            this.lblMsbtListSelectIndex.Text = "null";
             // 
-            // lblFLW2ListSelectIndex
+            // lblFlw2ListSelectIndex
             // 
-            this.lblFLW2ListSelectIndex.AutoSize = true;
-            this.lblFLW2ListSelectIndex.Location = new System.Drawing.Point(399, 14);
-            this.lblFLW2ListSelectIndex.Name = "lblFLW2ListSelectIndex";
-            this.lblFLW2ListSelectIndex.Size = new System.Drawing.Size(23, 12);
-            this.lblFLW2ListSelectIndex.TabIndex = 12;
-            this.lblFLW2ListSelectIndex.Text = "null";
+            this.lblFlw2ListSelectIndex.AutoSize = true;
+            this.lblFlw2ListSelectIndex.Location = new System.Drawing.Point(399, 14);
+            this.lblFlw2ListSelectIndex.Name = "lblFlw2ListSelectIndex";
+            this.lblFlw2ListSelectIndex.Size = new System.Drawing.Size(23, 12);
+            this.lblFlw2ListSelectIndex.TabIndex = 12;
+            this.lblFlw2ListSelectIndex.Text = "null";
             // 
-            // lblFEN1ListSelectIndex
+            // lblFen1ListSelectIndex
             // 
-            this.lblFEN1ListSelectIndex.AutoSize = true;
-            this.lblFEN1ListSelectIndex.Location = new System.Drawing.Point(397, 226);
-            this.lblFEN1ListSelectIndex.Name = "lblFEN1ListSelectIndex";
-            this.lblFEN1ListSelectIndex.Size = new System.Drawing.Size(23, 12);
-            this.lblFEN1ListSelectIndex.TabIndex = 13;
-            this.lblFEN1ListSelectIndex.Text = "null";
+            this.lblFen1ListSelectIndex.AutoSize = true;
+            this.lblFen1ListSelectIndex.Location = new System.Drawing.Point(397, 226);
+            this.lblFen1ListSelectIndex.Name = "lblFen1ListSelectIndex";
+            this.lblFen1ListSelectIndex.Size = new System.Drawing.Size(23, 12);
+            this.lblFen1ListSelectIndex.TabIndex = 13;
+            this.lblFen1ListSelectIndex.Text = "null";
             // 
             // tabControl3
             // 
-            this.tabControl3.Controls.Add(this.tbpFilesInsideRARC);
-            this.tabControl3.Controls.Add(this.tbpListsInsideMSB);
+            this.tabControl3.Controls.Add(this.tbpFilesInsideRarc);
+            this.tabControl3.Controls.Add(this.tbpListsInsideMsb);
             this.tabControl3.Location = new System.Drawing.Point(12, 28);
             this.tabControl3.Name = "tabControl3";
             this.tabControl3.SelectedIndex = 0;
             this.tabControl3.Size = new System.Drawing.Size(438, 483);
             this.tabControl3.TabIndex = 14;
             // 
-            // tbpFilesInsideRARC
+            // tbpFilesInsideRarc
             // 
-            this.tbpFilesInsideRARC.Controls.Add(this.chkMSBAutoSave);
-            this.tbpFilesInsideRARC.Controls.Add(this.lblSaveSystemDiscription);
-            this.tbpFilesInsideRARC.Controls.Add(this.lstFilesInsideRARC);
-            this.tbpFilesInsideRARC.Location = new System.Drawing.Point(4, 22);
-            this.tbpFilesInsideRARC.Name = "tbpFilesInsideRARC";
-            this.tbpFilesInsideRARC.Padding = new System.Windows.Forms.Padding(3);
-            this.tbpFilesInsideRARC.Size = new System.Drawing.Size(430, 457);
-            this.tbpFilesInsideRARC.TabIndex = 0;
-            this.tbpFilesInsideRARC.Text = "ARCファイルの中身";
-            this.tbpFilesInsideRARC.UseVisualStyleBackColor = true;
+            this.tbpFilesInsideRarc.Controls.Add(this.chkMsbAutoSave);
+            this.tbpFilesInsideRarc.Controls.Add(this.lblSaveSystemDiscription);
+            this.tbpFilesInsideRarc.Controls.Add(this.lstFilesInsideRarc);
+            this.tbpFilesInsideRarc.Location = new System.Drawing.Point(4, 22);
+            this.tbpFilesInsideRarc.Name = "tbpFilesInsideRarc";
+            this.tbpFilesInsideRarc.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpFilesInsideRarc.Size = new System.Drawing.Size(430, 457);
+            this.tbpFilesInsideRarc.TabIndex = 0;
+            this.tbpFilesInsideRarc.Text = "ARCファイルの中身";
+            this.tbpFilesInsideRarc.UseVisualStyleBackColor = true;
             // 
-            // chkMSBAutoSave
+            // chkMsbAutoSave
             // 
-            this.chkMSBAutoSave.AutoSize = true;
-            this.chkMSBAutoSave.Location = new System.Drawing.Point(223, 268);
-            this.chkMSBAutoSave.Name = "chkMSBAutoSave";
-            this.chkMSBAutoSave.Size = new System.Drawing.Size(201, 16);
-            this.chkMSBAutoSave.TabIndex = 2;
-            this.chkMSBAutoSave.Text = "(Msbt Msbf) オートセーブ/AutoSave";
-            this.chkMSBAutoSave.UseVisualStyleBackColor = true;
-            this.chkMSBAutoSave.CheckedChanged += new System.EventHandler(this.ChkMSBAutoSave_CheckedChanged);
+            this.chkMsbAutoSave.AutoSize = true;
+            this.chkMsbAutoSave.Location = new System.Drawing.Point(223, 268);
+            this.chkMsbAutoSave.Name = "chkMsbAutoSave";
+            this.chkMsbAutoSave.Size = new System.Drawing.Size(201, 16);
+            this.chkMsbAutoSave.TabIndex = 2;
+            this.chkMsbAutoSave.Text = "(Msbt Msbf) オートセーブ/AutoSave";
+            this.chkMsbAutoSave.UseVisualStyleBackColor = true;
+            this.chkMsbAutoSave.CheckedChanged += new System.EventHandler(this.ChkMsbAutoSave_CheckedChanged);
             // 
             // lblSaveSystemDiscription
             // 
@@ -2613,38 +2613,38 @@ namespace MSBT_Editor
             this.lblSaveSystemDiscription.Text = "ARCファイルから開いた\r\nMsbtやMsbfの内容を変更した際は上書き保存をしてください。\r\n上書き保存してからリストを選択し直さないと、\r\n変更が保存されませ" +
     "ん。\r\n全ての変更が終わったらARCを保存してください。";
             // 
-            // lstFilesInsideRARC
+            // lstFilesInsideRarc
             // 
-            this.lstFilesInsideRARC.FormattingEnabled = true;
-            this.lstFilesInsideRARC.ItemHeight = 12;
-            this.lstFilesInsideRARC.Location = new System.Drawing.Point(6, 6);
-            this.lstFilesInsideRARC.Name = "lstFilesInsideRARC";
-            this.lstFilesInsideRARC.Size = new System.Drawing.Size(418, 256);
-            this.lstFilesInsideRARC.TabIndex = 0;
-            this.lstFilesInsideRARC.SelectedIndexChanged += new System.EventHandler(this.LstFilesInsideRARC_SelectedIndexChanged);
-            this.lstFilesInsideRARC.SelectedValueChanged += new System.EventHandler(this.LstFilesInsideRARC_SelectedValueChanged);
-            this.lstFilesInsideRARC.CursorChanged += new System.EventHandler(this.LstFilesInsideRARC_CursorChanged);
-            this.lstFilesInsideRARC.ChangeUICues += new System.Windows.Forms.UICuesEventHandler(this.LstFilesInsideRARC_ChangeUICues);
-            this.lstFilesInsideRARC.Validating += new System.ComponentModel.CancelEventHandler(this.LstFilesInsideRARC_Validating);
+            this.lstFilesInsideRarc.FormattingEnabled = true;
+            this.lstFilesInsideRarc.ItemHeight = 12;
+            this.lstFilesInsideRarc.Location = new System.Drawing.Point(6, 6);
+            this.lstFilesInsideRarc.Name = "lstFilesInsideRarc";
+            this.lstFilesInsideRarc.Size = new System.Drawing.Size(418, 256);
+            this.lstFilesInsideRarc.TabIndex = 0;
+            this.lstFilesInsideRarc.SelectedIndexChanged += new System.EventHandler(this.LstFilesInsideRarc_SelectedIndexChanged);
+            this.lstFilesInsideRarc.SelectedValueChanged += new System.EventHandler(this.LstFilesInsideRarc_SelectedValueChanged);
+            this.lstFilesInsideRarc.CursorChanged += new System.EventHandler(this.LstFilesInsideRarc_CursorChanged);
+            this.lstFilesInsideRarc.ChangeUICues += new System.Windows.Forms.UICuesEventHandler(this.LstFilesInsideRarc_ChangeUICues);
+            this.lstFilesInsideRarc.Validating += new System.ComponentModel.CancelEventHandler(this.LstFilesInsideRarc_Validating);
             // 
-            // tbpListsInsideMSB
+            // tbpListsInsideMsb
             // 
-            this.tbpListsInsideMSB.Controls.Add(this.lblMSBT);
-            this.tbpListsInsideMSB.Controls.Add(this.lblFEN1ListSelectIndex);
-            this.tbpListsInsideMSB.Controls.Add(this.lblFLW2ListSelectIndex);
-            this.tbpListsInsideMSB.Controls.Add(this.lstListsInsideMSBT);
-            this.tbpListsInsideMSB.Controls.Add(this.lblFEN1);
-            this.tbpListsInsideMSB.Controls.Add(this.lstListsInsideFLW2);
-            this.tbpListsInsideMSB.Controls.Add(this.lblMSBTListSelectIndex);
-            this.tbpListsInsideMSB.Controls.Add(this.lstListsInsideFEN1);
-            this.tbpListsInsideMSB.Controls.Add(this.lblFLW2);
-            this.tbpListsInsideMSB.Location = new System.Drawing.Point(4, 22);
-            this.tbpListsInsideMSB.Name = "tbpListsInsideMSB";
-            this.tbpListsInsideMSB.Padding = new System.Windows.Forms.Padding(3);
-            this.tbpListsInsideMSB.Size = new System.Drawing.Size(430, 457);
-            this.tbpListsInsideMSB.TabIndex = 1;
-            this.tbpListsInsideMSB.Text = "MSBTとMSBF";
-            this.tbpListsInsideMSB.UseVisualStyleBackColor = true;
+            this.tbpListsInsideMsb.Controls.Add(this.lblMsbt);
+            this.tbpListsInsideMsb.Controls.Add(this.lblFen1ListSelectIndex);
+            this.tbpListsInsideMsb.Controls.Add(this.lblFlw2ListSelectIndex);
+            this.tbpListsInsideMsb.Controls.Add(this.lstListsInsideMsbt);
+            this.tbpListsInsideMsb.Controls.Add(this.lblFen1);
+            this.tbpListsInsideMsb.Controls.Add(this.lstListsInsideFlw2);
+            this.tbpListsInsideMsb.Controls.Add(this.lblMsbtListSelectIndex);
+            this.tbpListsInsideMsb.Controls.Add(this.lstListsInsideFen1);
+            this.tbpListsInsideMsb.Controls.Add(this.lblFlw2);
+            this.tbpListsInsideMsb.Location = new System.Drawing.Point(4, 22);
+            this.tbpListsInsideMsb.Name = "tbpListsInsideMsb";
+            this.tbpListsInsideMsb.Padding = new System.Windows.Forms.Padding(3);
+            this.tbpListsInsideMsb.Size = new System.Drawing.Size(430, 457);
+            this.tbpListsInsideMsb.TabIndex = 1;
+            this.tbpListsInsideMsb.Text = "MSBTとMSBF";
+            this.tbpListsInsideMsb.UseVisualStyleBackColor = true;
             // 
             // Form1
             // 
@@ -2672,50 +2672,50 @@ namespace MSBT_Editor
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.tabControl1.ResumeLayout(false);
-            this.tbpMSBTSettings.ResumeLayout(false);
-            this.gbxMSBTSettingsATR1.ResumeLayout(false);
-            this.gbxMSBTSettingsATR1.PerformLayout();
-            this.tabPage2.ResumeLayout(false);
-            this.tabPage2.PerformLayout();
+            this.tbpMsbtSetting.ResumeLayout(false);
+            this.gbxMsbtSettingsAtr1.ResumeLayout(false);
+            this.gbxMsbtSettingsAtr1.PerformLayout();
+            this.tbpMsbtTextEdit.ResumeLayout(false);
+            this.tbpMsbtTextEdit.PerformLayout();
             this.tabControl2.ResumeLayout(false);
-            this.tabPage6.ResumeLayout(false);
-            this.tabPage7.ResumeLayout(false);
+            this.tbpGeneralTag.ResumeLayout(false);
+            this.tbpValueTag.ResumeLayout(false);
             this.gbxTimerTag.ResumeLayout(false);
             this.gbxTimerTag.PerformLayout();
             this.gbxRubiTag.ResumeLayout(false);
             this.gbxRubiTag.PerformLayout();
-            this.tabPage8.ResumeLayout(false);
+            this.tbpSpecialTag.ResumeLayout(false);
             this.gbxSpecialTag.ResumeLayout(false);
-            this.tabPage9.ResumeLayout(false);
-            this.tabPage9.PerformLayout();
+            this.tbpIconTag.ResumeLayout(false);
+            this.tbpIconTag.PerformLayout();
             this.AdvancedTagsTabPage.ResumeLayout(false);
             this.gbxSoundEffectTag.ResumeLayout(false);
             this.gbxSoundEffectTag.PerformLayout();
             this.gbxCustomIconTag.ResumeLayout(false);
             this.gbxCustomIconTag.PerformLayout();
             this.tbpListEdit.ResumeLayout(false);
-            this.gbxListEditFEN1.ResumeLayout(false);
-            this.gbxListEditFEN1.PerformLayout();
-            this.gbxListEditFLW2.ResumeLayout(false);
-            this.gbxListEditFLW2.PerformLayout();
-            this.gbxListEditMSBT.ResumeLayout(false);
-            this.gbxListEditMSBT.PerformLayout();
-            this.tbpMSBFSetting.ResumeLayout(false);
-            this.tbpMSBFSetting.PerformLayout();
-            this.gbxFEN1.ResumeLayout(false);
-            this.gbxFEN1.PerformLayout();
-            this.gbxFLW2.ResumeLayout(false);
-            this.gbxFLW2.PerformLayout();
-            this.gbxFLW2Branch.ResumeLayout(false);
-            this.gbxFLW2Branch.PerformLayout();
-            this.tbpDebugMSBF.ResumeLayout(false);
-            this.tbpDebugMSBF.PerformLayout();
+            this.gbxListEditFen1.ResumeLayout(false);
+            this.gbxListEditFen1.PerformLayout();
+            this.gbxListEditFlw2.ResumeLayout(false);
+            this.gbxListEditFlw2.PerformLayout();
+            this.gbxListEditMsbt.ResumeLayout(false);
+            this.gbxListEditMsbt.PerformLayout();
+            this.tbpMsbfSetting.ResumeLayout(false);
+            this.tbpMsbfSetting.PerformLayout();
+            this.gbxFen1.ResumeLayout(false);
+            this.gbxFen1.PerformLayout();
+            this.gbxFlw2.ResumeLayout(false);
+            this.gbxFlw2.PerformLayout();
+            this.gbxFlw2Branch.ResumeLayout(false);
+            this.gbxFlw2Branch.PerformLayout();
+            this.tbpDebugMsbf.ResumeLayout(false);
+            this.tbpDebugMsbf.PerformLayout();
             this.tbpDebug.ResumeLayout(false);
             this.tbpDebug.PerformLayout();
             this.tbpCredit.ResumeLayout(false);
             this.tbpCredit.PerformLayout();
-            this.gbxCreditLBL1.ResumeLayout(false);
-            this.gbxCreditLBL1.PerformLayout();
+            this.gbxCreditLbl1.ResumeLayout(false);
+            this.gbxCreditLbl1.PerformLayout();
             this.gbxCreditProgrammer.ResumeLayout(false);
             this.gbxCreditProgrammer.PerformLayout();
             this.gbxCreditContributor.ResumeLayout(false);
@@ -2733,10 +2733,10 @@ namespace MSBT_Editor
             this.gbxHowToUse.ResumeLayout(false);
             this.gbxHowToUse.PerformLayout();
             this.tabControl3.ResumeLayout(false);
-            this.tbpFilesInsideRARC.ResumeLayout(false);
-            this.tbpFilesInsideRARC.PerformLayout();
-            this.tbpListsInsideMSB.ResumeLayout(false);
-            this.tbpListsInsideMSB.PerformLayout();
+            this.tbpFilesInsideRarc.ResumeLayout(false);
+            this.tbpFilesInsideRarc.PerformLayout();
+            this.tbpListsInsideMsb.ResumeLayout(false);
+            this.tbpListsInsideMsb.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -2746,61 +2746,61 @@ namespace MSBT_Editor
 
         private System.Windows.Forms.StatusStrip stbStatusBar;
         private System.Windows.Forms.MenuStrip menuStrip1;
-        public System.Windows.Forms.TextBox txtMSBTText;
-        public System.Windows.Forms.ListBox lstListsInsideMSBT;
-        public System.Windows.Forms.ToolStripStatusLabel stbOpenedMSBTName;
+        public System.Windows.Forms.TextBox txtMsbtText;
+        public System.Windows.Forms.ListBox lstListsInsideMsbt;
+        public System.Windows.Forms.ToolStripStatusLabel stbOpenedMsbtName;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel3;
-        public System.Windows.Forms.ToolStripStatusLabel stbOpenedMSBFName;
+        public System.Windows.Forms.ToolStripStatusLabel stbOpenedMsbfName;
         public System.Windows.Forms.TextBox textBox2;
-        private System.Windows.Forms.TextBox txtATR1SpecialTextOffset;
-        private System.Windows.Forms.TextBox txtATR1Unknown6;
-        private System.Windows.Forms.TextBox txtATR1MessageAreaID;
-        private System.Windows.Forms.TextBox txtATR1EventCameraID;
-        private System.Windows.Forms.TextBox txtATR1WindowID;
-        private System.Windows.Forms.TextBox txtATR1DialogID;
-        private System.Windows.Forms.TextBox txtATR1SimpleCamID;
-        private System.Windows.Forms.TextBox txtATR1SoundID;
-        private System.Windows.Forms.TextBox txtLBL1TagIndex;
-        public System.Windows.Forms.TextBox textBox13;
-        public System.Windows.Forms.TextBox txtATR1SpecialText;
+        private System.Windows.Forms.TextBox txtAtr1SpecialTextOffset;
+        private System.Windows.Forms.TextBox txtAtr1Unknown6;
+        private System.Windows.Forms.TextBox txtAtr1MessageAreaID;
+        private System.Windows.Forms.TextBox txtAtr1EventCameraID;
+        private System.Windows.Forms.TextBox txtAtr1WindowID;
+        private System.Windows.Forms.TextBox txtAtr1DialogID;
+        private System.Windows.Forms.TextBox txtAtr1SimpleCamID;
+        private System.Windows.Forms.TextBox txtAtr1SoundID;
+        private System.Windows.Forms.TextBox txtLbl1TagIndex;
+        public System.Windows.Forms.TextBox txtFlw2DebugHex;
+        public System.Windows.Forms.TextBox txtAtr1SpecialText;
         public System.Windows.Forms.TextBox MSBT_Debug_Text;
-        private System.Windows.Forms.TabPage tbpDebugMSBF;
-        private System.Windows.Forms.TextBox txtMSBTListName;
-        private System.Windows.Forms.GroupBox gbxCreditLBL1;
-        private System.Windows.Forms.Label lblLBL1EntrySize;
-        public System.Windows.Forms.TextBox txtLBL1EntrySize;
-        private System.Windows.Forms.Label lblATR1EntrySize;
-        public System.Windows.Forms.TextBox txtATR1EntrySize;
+        private System.Windows.Forms.TabPage tbpDebugMsbf;
+        private System.Windows.Forms.TextBox txtMsbtListName;
+        private System.Windows.Forms.GroupBox gbxCreditLbl1;
+        private System.Windows.Forms.Label lblLbl1EntrySize;
+        public System.Windows.Forms.TextBox txtLbl1EntrySize;
+        private System.Windows.Forms.Label lblAtr1EntrySize;
+        public System.Windows.Forms.TextBox txtAtr1EntrySize;
         private System.Windows.Forms.Button btnReleaseDebugTextFile;
-        private System.Windows.Forms.TextBox txtFLW2BranchFalse;
-        private System.Windows.Forms.TextBox txtFLW2BranchTrue;
-        private System.Windows.Forms.GroupBox gbxFLW2;
-        public System.Windows.Forms.TextBox txtFLW2Arg4;
-        public System.Windows.Forms.TextBox txtFLW2Arg3;
-        public System.Windows.Forms.TextBox txtFLW2Arg2;
-        public System.Windows.Forms.TextBox txtFLW2Arg1;
-        public System.Windows.Forms.TextBox txtFLW2Padding;
-        public System.Windows.Forms.TextBox txtFLW2FlowType;
-        public System.Windows.Forms.ListBox lstListsInsideFLW2;
+        private System.Windows.Forms.TextBox txtFlw2BranchFalse;
+        private System.Windows.Forms.TextBox txtFlw2BranchTrue;
+        private System.Windows.Forms.GroupBox gbxFlw2;
+        public System.Windows.Forms.TextBox txtFlw2Arg4;
+        public System.Windows.Forms.TextBox txtFlw2Arg3;
+        public System.Windows.Forms.TextBox txtFlw2Arg2;
+        public System.Windows.Forms.TextBox txtFlw2Arg1;
+        public System.Windows.Forms.TextBox txtFlw2Padding;
+        public System.Windows.Forms.TextBox txtFlw2FlowType;
+        public System.Windows.Forms.ListBox lstListsInsideFlw2;
         private System.Windows.Forms.TabPage tbpDebug;
         public System.Windows.Forms.TextBox textBox27;
-        private System.Windows.Forms.GroupBox gbxFEN1;
-        public System.Windows.Forms.ListBox lstListsInsideFEN1;
-        private System.Windows.Forms.TextBox txtFEN1StartIndex;
-        private System.Windows.Forms.TextBox txtFEN1Arg0;
-        private System.Windows.Forms.GroupBox gbxListEditMSBT;
-        public System.Windows.Forms.Label lblFLW2Arg4;
-        public System.Windows.Forms.Label lblFLW2Arg3;
-        public System.Windows.Forms.Label lblFLW2Arg2;
-        public System.Windows.Forms.Label lblFLW2Arg1;
+        private System.Windows.Forms.GroupBox gbxFen1;
+        public System.Windows.Forms.ListBox lstListsInsideFen1;
+        private System.Windows.Forms.TextBox txtFen1StartIndex;
+        private System.Windows.Forms.TextBox txtFen1Arg0;
+        private System.Windows.Forms.GroupBox gbxListEditMsbt;
+        public System.Windows.Forms.Label lblFlw2Arg4;
+        public System.Windows.Forms.Label lblFlw2Arg3;
+        public System.Windows.Forms.Label lblFlw2Arg2;
+        public System.Windows.Forms.Label lblFlw2Arg1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-        private System.Windows.Forms.GroupBox gbxListEditFEN1;
-        private System.Windows.Forms.TextBox txtFEN1ListName;
-        private System.Windows.Forms.GroupBox gbxListEditFLW2;
-        private System.Windows.Forms.TextBox txtSelectedMSBTListName;
-        private System.Windows.Forms.Label lblMSBT;
-        private System.Windows.Forms.Label lblFLW2;
-        private System.Windows.Forms.Label lblFEN1;
+        private System.Windows.Forms.GroupBox gbxListEditFen1;
+        private System.Windows.Forms.TextBox txtFen1ListName;
+        private System.Windows.Forms.GroupBox gbxListEditFlw2;
+        private System.Windows.Forms.TextBox txtSelectedMsbtListName;
+        private System.Windows.Forms.Label lblMsbt;
+        private System.Windows.Forms.Label lblFlw2;
+        private System.Windows.Forms.Label lblFen1;
         private System.Windows.Forms.ComboBox cmbLanguage;
         private System.Windows.Forms.Label lblLanguage;
         public System.Windows.Forms.ToolStripStatusLabel stbStatusLabel;
@@ -2812,46 +2812,46 @@ namespace MSBT_Editor
         public System.Windows.Forms.ToolStripMenuItem Msbf上書き保存ToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem Msbf保存ToolStripMenuItem;
         public System.Windows.Forms.TabControl tabControl1;
-        public System.Windows.Forms.TabPage tbpMSBTSettings;
-        public System.Windows.Forms.TabPage tabPage2;
+        public System.Windows.Forms.TabPage tbpMsbtSetting;
+        public System.Windows.Forms.TabPage tbpMsbtTextEdit;
         public System.Windows.Forms.TabPage tbpListEdit;
-        public System.Windows.Forms.TabPage tbpMSBFSetting;
-        public System.Windows.Forms.Label lblATR1SpecialTextOffset;
-        public System.Windows.Forms.Label lblATR1Unknown6;
-        public System.Windows.Forms.Label lblATR1MessageAreaID;
-        public System.Windows.Forms.Label lblATR1EventCameraID;
-        public System.Windows.Forms.Label lblATR1WindowID;
-        public System.Windows.Forms.Label lblATR1DialogID;
-        public System.Windows.Forms.Label lblATR1SimpleCamID;
-        public System.Windows.Forms.Label lblATR1SoundID;
-        public System.Windows.Forms.Label lblATR1SpecialText;
-        public System.Windows.Forms.Label lblLBL1TagIndex;
-        public System.Windows.Forms.Label lblCreditLBL1Note;
-        public System.Windows.Forms.Label lblFLW2BranchFalse;
-        public System.Windows.Forms.Label lblFLW2BranchTrue;
-        public System.Windows.Forms.Label lblFLW2Padding;
-        public System.Windows.Forms.Label lblFLW2FlowType;
-        public System.Windows.Forms.Label lblFLW2StartIndex;
-        public System.Windows.Forms.Label lblFEN1Arg0;
-        public System.Windows.Forms.GroupBox gbxFLW2Branch;
-        private System.Windows.Forms.Label label41;
-        public System.Windows.Forms.Label lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote;
-        public System.Windows.Forms.Button btnAddMSBTList;
-        public System.Windows.Forms.Button btnDeleteMSBTList;
-        public System.Windows.Forms.Label lblMSBTListEditNote;
-        public System.Windows.Forms.Label lblMSBTListEditDiscription;
-        public System.Windows.Forms.Label lblMSBTListName;
-        public System.Windows.Forms.Button btnDeleteFEN1List;
-        public System.Windows.Forms.Button btnAddFEN1List;
-        public System.Windows.Forms.Label lblFEN1ListName;
-        public System.Windows.Forms.Button btnDeleteFLW2List;
-        public System.Windows.Forms.Button btnAddFLW2List;
-        public System.Windows.Forms.Label lblFLW2ListEditDiscription;
+        public System.Windows.Forms.TabPage tbpMsbfSetting;
+        public System.Windows.Forms.Label lblAtr1SpecialTextOffset;
+        public System.Windows.Forms.Label lblAtr1Unknown6;
+        public System.Windows.Forms.Label lblAtr1MessageAreaID;
+        public System.Windows.Forms.Label lblAtr1EventCameraID;
+        public System.Windows.Forms.Label lblAtr1WindowID;
+        public System.Windows.Forms.Label lblAtr1DialogID;
+        public System.Windows.Forms.Label lblAtr1SimpleCamID;
+        public System.Windows.Forms.Label lblAtr1SoundID;
+        public System.Windows.Forms.Label lblAtr1SpecialText;
+        public System.Windows.Forms.Label lblLbl1TagIndex;
+        public System.Windows.Forms.Label lblCreditLbl1Note;
+        public System.Windows.Forms.Label lblFlw2BranchFalse;
+        public System.Windows.Forms.Label lblFlw2BranchTrue;
+        public System.Windows.Forms.Label lblFlw2Padding;
+        public System.Windows.Forms.Label lblFlw2FlowType;
+        public System.Windows.Forms.Label lblFlw2StartIndex;
+        public System.Windows.Forms.Label lblFen1Arg0;
+        public System.Windows.Forms.GroupBox gbxFlw2Branch;
+        private System.Windows.Forms.Label lblFlw2RightAngleSymbol;
+        public System.Windows.Forms.Label lblCreditSectionEntrySize;
+        public System.Windows.Forms.Button btnAddMsbtList;
+        public System.Windows.Forms.Button btnDeleteMsbtList;
+        public System.Windows.Forms.Label lblMsbtListEditNote;
+        public System.Windows.Forms.Label lblMsbtListEditDiscription;
+        public System.Windows.Forms.Label lblMsbtListName;
+        public System.Windows.Forms.Button btnDeleteFen1List;
+        public System.Windows.Forms.Button btnAddFen1List;
+        public System.Windows.Forms.Label lblFen1ListName;
+        public System.Windows.Forms.Button btnDeleteFlw2List;
+        public System.Windows.Forms.Button btnAddFlw2List;
+        public System.Windows.Forms.Label lblFlw2ListEditDiscription;
         public System.Windows.Forms.TabControl tabControl2;
-        public System.Windows.Forms.TabPage tabPage6;
-        public System.Windows.Forms.TabPage tabPage7;
-        public System.Windows.Forms.TabPage tabPage8;
-        public System.Windows.Forms.TabPage tabPage9;
+        public System.Windows.Forms.TabPage tbpGeneralTag;
+        public System.Windows.Forms.TabPage tbpValueTag;
+        public System.Windows.Forms.TabPage tbpSpecialTag;
+        public System.Windows.Forms.TabPage tbpIconTag;
         public System.Windows.Forms.ComboBox cmbColorTag;
         public System.Windows.Forms.ComboBox cmbLineControlTag;
         public System.Windows.Forms.ComboBox cmbFontSizeTag;
@@ -2860,16 +2860,16 @@ namespace MSBT_Editor
         public System.Windows.Forms.Button btnInsertLineControlTag;
         public System.Windows.Forms.Button btnInsertFontSizeTag;
         public System.Windows.Forms.Button btnInsertCenterTag;
-        private System.Windows.Forms.Label lblMSBTListSelectIndex;
-        private System.Windows.Forms.Label lblFLW2ListSelectIndex;
-        private System.Windows.Forms.Label lblFEN1ListSelectIndex;
+        private System.Windows.Forms.Label lblMsbtListSelectIndex;
+        private System.Windows.Forms.Label lblFlw2ListSelectIndex;
+        private System.Windows.Forms.Label lblFen1ListSelectIndex;
         public System.Windows.Forms.GroupBox gbxCreditSectionEntrySize;
-        public System.Windows.Forms.Label lblMSBFSettingNote;
-        public System.Windows.Forms.TreeView tvwMSBFFlow;
-        public System.Windows.Forms.TextBox UnknownTag;
+        public System.Windows.Forms.Label lblMsbfSettingNote;
+        public System.Windows.Forms.TreeView tvwMsbfFlow;
+        public System.Windows.Forms.TextBox txtUnknownTag;
         private System.Windows.Forms.Button btnCalculateHash;
         private System.Windows.Forms.TextBox txtListNameToCalculateHash;
-        private System.Windows.Forms.Label lblMSBFFlow;
+        private System.Windows.Forms.Label lblMsbfFlow;
         public System.Windows.Forms.ComboBox cmbCharacterIconTag;
         public System.Windows.Forms.ComboBox cmbObjectIconTag;
         public System.Windows.Forms.ComboBox cmbOthersIconTag;
@@ -2922,42 +2922,42 @@ namespace MSBT_Editor
         public System.Windows.Forms.ToolStripStatusLabel stbSavedFilePathLabel;
         public System.Windows.Forms.ToolStripStatusLabel stbSavedFilePath;
         private System.Windows.Forms.TextBox textBox34;
-        private System.Windows.Forms.TextBox txtReadOnlyMSBTText;
-        private System.Windows.Forms.Button btnReloadTvwMSBFFlow;
+        private System.Windows.Forms.TextBox txtReadOnlyMsbtText;
+        private System.Windows.Forms.Button btnReloadTvwMsbfFlow;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
-        public System.Windows.Forms.CheckBox chkShowTvwMSBFFlow;
-        private System.Windows.Forms.Label lblMSBFHashCalculator;
-        private System.Windows.Forms.Label label55;
-        private System.Windows.Forms.Label label54;
-        private System.Windows.Forms.TabPage tbpListsInsideMSB;
+        public System.Windows.Forms.CheckBox chkShowTvwMsbfFlow;
+        private System.Windows.Forms.Label lblMsbfHashCalculator;
+        private System.Windows.Forms.Label lblDebuggerAcknowledgment;
+        private System.Windows.Forms.Label lblCreditContributorAcknowledgment;
+        private System.Windows.Forms.TabPage tbpListsInsideMsb;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel8;
-        public System.Windows.Forms.ToolStripStatusLabel stbOpenedRARCName;
+        public System.Windows.Forms.ToolStripStatusLabel stbOpenedRarcName;
         private System.Windows.Forms.TextBox txtCustomIconHex;
         private System.Windows.Forms.TextBox txtSoundEffectName;
-        public System.Windows.Forms.ListBox lstFilesInsideRARC;
+        public System.Windows.Forms.ListBox lstFilesInsideRarc;
         public System.Windows.Forms.Label lblSaveSystemDiscription;
-        public System.Windows.Forms.GroupBox gbxMSBTSettingsATR1;
+        public System.Windows.Forms.GroupBox gbxMsbtSettingsAtr1;
         public System.Windows.Forms.TabPage AdvancedTagsTabPage;
         private System.Windows.Forms.GroupBox gbxCreditDebuggerVIP;
         private System.Windows.Forms.GroupBox gbxCreditContributor;
         private System.Windows.Forms.GroupBox gbxHowToUse;
-        private System.Windows.Forms.Label lblSMG2HackWikiURL;
-        private System.Windows.Forms.LinkLabel llbSMG2HackWikiURL;
-        private System.Windows.Forms.Label lblSMG2HackDiscordURL;
-        private System.Windows.Forms.LinkLabel llbSMG2HackDiscordURL;
-        private System.Windows.Forms.Label lblGitHubIssuesURL;
-        private System.Windows.Forms.LinkLabel llbGitHubIssuesURL;
-        private System.Windows.Forms.Label lblGitHubRepositoryURL;
-        private System.Windows.Forms.LinkLabel llbGitHubRepositoryURL;
-        private System.Windows.Forms.Label lblGitHubReleasesURL;
-        private System.Windows.Forms.LinkLabel llbGitHubReleasesURL;
+        private System.Windows.Forms.Label lblSMG2HackWikiUrl;
+        private System.Windows.Forms.LinkLabel llbSMG2HackWikiUrl;
+        private System.Windows.Forms.Label lblSMG2HackDiscordUrl;
+        private System.Windows.Forms.LinkLabel llbSMG2HackDiscordUrl;
+        private System.Windows.Forms.Label lblGitHubIssuesUrl;
+        private System.Windows.Forms.LinkLabel llbGitHubIssuesUrl;
+        private System.Windows.Forms.Label lblGitHubRepositoryUrl;
+        private System.Windows.Forms.LinkLabel llbGitHubRepositoryUrl;
+        private System.Windows.Forms.Label lblGitHubReleasesUrl;
+        private System.Windows.Forms.LinkLabel llbGitHubReleasesUrl;
         private System.Windows.Forms.Label lblCurrentVersion;
         private System.Windows.Forms.GroupBox gbxCurrentVersion;
         public System.Windows.Forms.ToolStripMenuItem ARC開くToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem ARC上書き保存ToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem ARC保存ToolStripMenuItem;
         public System.Windows.Forms.TabControl tabControl3;
-        public System.Windows.Forms.TabPage tbpFilesInsideRARC;
+        public System.Windows.Forms.TabPage tbpFilesInsideRarc;
         public System.Windows.Forms.Button btnInsertCustomIconTag;
         public System.Windows.Forms.GroupBox gbxCustomIconTag;
         public System.Windows.Forms.Label lblCustomIconHex;
@@ -2968,9 +2968,9 @@ namespace MSBT_Editor
         public System.Windows.Forms.Label lblSoundEffectTagDiscription2;
         public System.Windows.Forms.TabPage tbpInfomation;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button btnTextSort;
         private System.Windows.Forms.Label lblRubiTagDiscription;
-        private System.Windows.Forms.CheckBox chkMSBAutoSave;
+        private System.Windows.Forms.CheckBox chkMsbAutoSave;
         private System.Windows.Forms.TextBox textBox1;
     }
 }

--- a/MSBT_Editor/Form1.cs
+++ b/MSBT_Editor/Form1.cs
@@ -65,7 +65,7 @@ namespace MSBT_Editor
             cmbLanguage.Text = Properties.Settings.Default.言語;
             Langage.Langage_Check();
 
-            chkShowTvwMSBFFlow.Checked = true;
+            chkShowTvwMsbfFlow.Checked = true;
 
             //コマンドライン引数を配列で取得する
             string[] FilePathStrings = Environment.GetCommandLineArgs();
@@ -91,13 +91,13 @@ namespace MSBT_Editor
             foreach (var item in fileName)
             {
                 Dialog.FileCheck(item);
-                if ((stbOpenedMSBTName.Text
+                if ((stbOpenedMsbtName.Text
                     == Langage.FileReadStatusJP[0]) ||
-                    (stbOpenedMSBTName.Text
+                    (stbOpenedMsbtName.Text
                     == Langage.FileReadStatusUS[0]))
                     return;
                 string appPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
-                string msbtname = Path.GetFileNameWithoutExtension(stbOpenedMSBTName.Text);
+                string msbtname = Path.GetFileNameWithoutExtension(stbOpenedMsbtName.Text);
                 string textpath = Path.Combine(Path.GetDirectoryName(appPath), "Debug_" + msbtname + ".txt");
                 textBox34.AppendText(textpath + Environment.NewLine);
                 //File.WriteAllText(textpath, UnknownTag.Text);
@@ -109,19 +109,19 @@ namespace MSBT_Editor
         {
             if (UseDebugMenue == false)
             {
-                lblMSBFHashCalculator.Visible = false;
+                lblMsbfHashCalculator.Visible = false;
                 txtListNameToCalculateHash.Visible = false;
                 btnCalculateHash.Visible = false;
                 textBox32.Visible = false;
                 textBox33.Visible = false;
-                textBox13.Visible = false;
+                txtFlw2DebugHex.Visible = false;
                 textBox34.Visible = false;
                 textBox2.Visible = false;
                 textBox27.Visible = false;
                 btnReleaseDebugTextFile.Visible = false;
                 MSBT_Debug_Text.Visible = false;
-                UnknownTag.Visible = false;
-                tabControl1.TabPages.Remove(tbpDebugMSBF);
+                txtUnknownTag.Visible = false;
+                tabControl1.TabPages.Remove(tbpDebugMsbf);
                 tabControl1.TabPages.Remove(tbpDebug);
             }
         }
@@ -148,7 +148,7 @@ namespace MSBT_Editor
             return lb.SelectedIndex;
         }
 
-        private void LstListsInsideMSBT_SelectedIndexChanged(object sender, EventArgs e)
+        private void LstListsInsideMsbt_SelectedIndexChanged(object sender, EventArgs e)
         {
             //if (MSBT_Data.MSBT_All_Data.Text.Count == default)
             //{
@@ -170,7 +170,7 @@ namespace MSBT_Editor
 
             if (MSBT_Data.MSBT_All_Data.Text.Count < 1) return;
 
-            var MsbtSelectIndex = ListBoxIndex_NegativeThenSetIndexZero(lstListsInsideMSBT);
+            var MsbtSelectIndex = ListBoxIndex_NegativeThenSetIndexZero(lstListsInsideMsbt);
             var MsbtAllData = MSBT_Data.MSBT_All_Data;
             var SpecialText = MSBT_Data.Atr1SpecialText;
             ATR1.AttributeData Tmp;
@@ -180,45 +180,45 @@ namespace MSBT_Editor
             }
             catch (Exception)
             {
-                MsbtSelectIndex = lstListsInsideMSBT.SelectedIndex = 0;
+                MsbtSelectIndex = lstListsInsideMsbt.SelectedIndex = 0;
                 Tmp = MsbtAllData.Item[MsbtSelectIndex];
             }
 
 
-            txtMSBTText.Text = MsbtAllData.Text[MsbtSelectIndex];
-            txtReadOnlyMSBTText.Text = txtMSBTText.Text;
-            txtATR1SoundID.Text = Tmp.SoundID.ToString("X2");
-            txtATR1SimpleCamID.Text = Tmp.SimpleCameraID.ToString("X2");
-            txtATR1DialogID.Text = Tmp.DialogID.ToString("X2");
-            txtATR1WindowID.Text = Tmp.WindowID.ToString("X2");
-            txtATR1EventCameraID.Text = Tmp.EventCameraID.ToString("X4");
-            txtATR1MessageAreaID.Text = Tmp.MessageAreaID.ToString("X2");
-            txtATR1Unknown6.Text = Tmp.unknown6.ToString("X2");
-            txtATR1SpecialTextOffset.Text = Tmp.SpecialTextOffset.ToString("X8");
-            txtATR1SpecialText.Text = SpecialText[MsbtSelectIndex];
-            txtSelectedMSBTListName.Text = lstListsInsideMSBT.Text;
-            lblMSBTListSelectIndex.Text = "0x" + lstListsInsideMSBT.SelectedIndex.ToString("X");
+            txtMsbtText.Text = MsbtAllData.Text[MsbtSelectIndex];
+            txtReadOnlyMsbtText.Text = txtMsbtText.Text;
+            txtAtr1SoundID.Text = Tmp.SoundID.ToString("X2");
+            txtAtr1SimpleCamID.Text = Tmp.SimpleCameraID.ToString("X2");
+            txtAtr1DialogID.Text = Tmp.DialogID.ToString("X2");
+            txtAtr1WindowID.Text = Tmp.WindowID.ToString("X2");
+            txtAtr1EventCameraID.Text = Tmp.EventCameraID.ToString("X4");
+            txtAtr1MessageAreaID.Text = Tmp.MessageAreaID.ToString("X2");
+            txtAtr1Unknown6.Text = Tmp.unknown6.ToString("X2");
+            txtAtr1SpecialTextOffset.Text = Tmp.SpecialTextOffset.ToString("X8");
+            txtAtr1SpecialText.Text = SpecialText[MsbtSelectIndex];
+            txtSelectedMsbtListName.Text = lstListsInsideMsbt.Text;
+            lblMsbtListSelectIndex.Text = "0x" + lstListsInsideMsbt.SelectedIndex.ToString("X");
 
             if (UseDebugMenue == false) return;
             //ハッシュスキップ数を表示
-            var FindMsbtListTextIndexNum = LBL1.NameList.IndexOf(lstListsInsideMSBT.Text);
+            var FindMsbtListTextIndexNum = LBL1.NameList.IndexOf(lstListsInsideMsbt.Text);
             if (-1 != FindMsbtListTextIndexNum)
             {
-                txtLBL1TagIndex.Text = LBL1.HashSkipList[FindMsbtListTextIndexNum].ToString("X8");
+                txtLbl1TagIndex.Text = LBL1.HashSkipList[FindMsbtListTextIndexNum].ToString("X8");
             }
             else
             {
-                txtLBL1TagIndex.Text = "";
+                txtLbl1TagIndex.Text = "";
             }
         }
 
         private void TxtATR1SoundID_TextChanged(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             //Console.WriteLine(e.GetType().FullName);
-            var Element = MSBT_Data.MSBT_All_Data.Item[lstListsInsideMSBT.SelectedIndex];
-            Element.SoundID = ATR1.ATR1TextBoxChange(txtATR1SoundID, Element.SoundID);
-            MSBT_Data.MSBT_All_Data.Item[lstListsInsideMSBT.SelectedIndex] = Element;
+            var Element = MSBT_Data.MSBT_All_Data.Item[lstListsInsideMsbt.SelectedIndex];
+            Element.SoundID = ATR1.ATR1TextBoxChange(txtAtr1SoundID, Element.SoundID);
+            MSBT_Data.MSBT_All_Data.Item[lstListsInsideMsbt.SelectedIndex] = Element;
         }
 
         private void ATR1_TextChanged(object sender, EventArgs e)
@@ -226,74 +226,74 @@ namespace MSBT_Editor
             //ATR1セクションのテキストボックスの変更を
             //纏めるためのメソッドを作成中
             Console.WriteLine(((TextBox)sender).Name);
-            ATR1.ATR1_Change(txtATR1SimpleCamID);
+            ATR1.ATR1_Change(txtAtr1SimpleCamID);
         }
 
-        private void TxtATR1SimpleCamID_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1SimpleCamID_TextChanged(object sender, EventArgs e)
         {
 
-            ATR1.ATR1_Change(txtATR1SimpleCamID);
+            ATR1.ATR1_Change(txtAtr1SimpleCamID);
         }
 
-        private void TxtATR1DialogID_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1DialogID_TextChanged(object sender, EventArgs e)
         {
-            ATR1.ATR1_Change(txtATR1DialogID);
+            ATR1.ATR1_Change(txtAtr1DialogID);
         }
 
-        private void TxtATR1WindowID_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1WindowID_TextChanged(object sender, EventArgs e)
         {
-            ATR1.ATR1_Change(txtATR1WindowID);
+            ATR1.ATR1_Change(txtAtr1WindowID);
         }
 
-        private void TxtATR1EventCameraID_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1EventCameraID_TextChanged(object sender, EventArgs e)
         {
-            ATR1.ATR1_Change(txtATR1EventCameraID);
+            ATR1.ATR1_Change(txtAtr1EventCameraID);
         }
 
-        private void TxtATR1MessageAreaID_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1MessageAreaID_TextChanged(object sender, EventArgs e)
         {
-            ATR1.ATR1_Change(txtATR1MessageAreaID);
+            ATR1.ATR1_Change(txtAtr1MessageAreaID);
         }
 
-        private void TxtATR1Unknown6_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1Unknown6_TextChanged(object sender, EventArgs e)
         {
-            ATR1.ATR1_Change(txtATR1Unknown6);
+            ATR1.ATR1_Change(txtAtr1Unknown6);
         }
 
-        private void TxtATR1SpecialText_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1SpecialText_TextChanged(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
-            ATR1.SpecialTextList[lstListsInsideMSBT.SelectedIndex] = txtATR1SpecialText.Text;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
+            ATR1.SpecialTextList[lstListsInsideMsbt.SelectedIndex] = txtAtr1SpecialText.Text;
 
         }
 
-        private void TxtLBL1TagIndex_TextChanged(object sender, EventArgs e)
+        private void TxtLbl1TagIndex_TextChanged(object sender, EventArgs e)
         {
-            var liststrs = lstListsInsideMSBT.Text;
+            var liststrs = lstListsInsideMsbt.Text;
             if (-1 != LBL1.NameList.IndexOf(liststrs))
             {
                 var unknownlbldata = LBL1.BeginEntryAdressList[LBL1.NameList.IndexOf(liststrs)].ToString("X");
-                LBL1.HashSkipList[LBL1.NameList.IndexOf(liststrs)] = Int32.Parse(txtLBL1TagIndex.Text, NumberStyles.HexNumber);
+                LBL1.HashSkipList[LBL1.NameList.IndexOf(liststrs)] = Int32.Parse(txtLbl1TagIndex.Text, NumberStyles.HexNumber);
             }
         }
 
         private void TxtMsbtText_TextChanged(object sender, EventArgs e)
         {
 
-            if (lstListsInsideMSBT.Items.Count != 0)
+            if (lstListsInsideMsbt.Items.Count != 0)
             {
-                MSBT_Data.MSBT_All_Data.Text[lstListsInsideMSBT.SelectedIndex] = txtMSBTText.Text;
+                MSBT_Data.MSBT_All_Data.Text[lstListsInsideMsbt.SelectedIndex] = txtMsbtText.Text;
             }
 
         }
 
         //非常によくない複雑で長い処理。改善する必要があります。
         //修正すると複数箇所に影響を及ぼすので慎重に修復する必要があります。
-        private void BtnAddMSBTList_Click(object sender, EventArgs e)
+        private void BtnAddMsbtList_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count != 0)
+            if (lstListsInsideMsbt.Items.Count != 0)
             {
-                if (txtMSBTListName.Text == string.Empty) return;
+                if (txtMsbtListName.Text == string.Empty) return;
 
                 LBL1 lbl1 = new LBL1
                 {
@@ -303,7 +303,7 @@ namespace MSBT_Editor
                 long ListCounter = 0;
 
                 //リストボックス1のデータをハッシュデータ構造体に入れる
-                foreach (var ListName in lstListsInsideMSBT.Items)
+                foreach (var ListName in lstListsInsideMsbt.Items)
                 {
                     var Hash = Calculation_System.MSBT_Hash(ListName.ToString(), lbl1.EntrySize);
                     lbl1.HashData.Add(new LBL1.Hash_Data(Hash, ListCounter));
@@ -312,7 +312,7 @@ namespace MSBT_Editor
 
                 var HashList = new List<LBL1.Hash_Data>(lbl1.HashData);
                 HashList.Sort((a, b) => a.Hash.CompareTo(b.Hash));
-                var NewHash = Calculation_System.MSBT_Hash(txtMSBTListName.Text, lbl1.EntrySize);
+                var NewHash = Calculation_System.MSBT_Hash(txtMsbtListName.Text, lbl1.EntrySize);
                 var HashMatchData = HashList.LastOrDefault(Old => Old.Hash == NewHash);
 
                 //ハッシュ値がデフォルトの場合、新しいハッシュ値がハッシュリストの値を超える値を返す
@@ -321,13 +321,13 @@ namespace MSBT_Editor
 
                 //ハッシュ値を基準に見つかったハッシュ構造体のリスト値に+1した値にリストを挿入する
                 HashMatchData.MsbtListBoxIndex++;
-                lstListsInsideMSBT.Items.Insert((int)HashMatchData.MsbtListBoxIndex, txtMSBTListName.Text);
+                lstListsInsideMsbt.Items.Insert((int)HashMatchData.MsbtListBoxIndex, txtMsbtListName.Text);
 
                 //リストボックスを名前順にソート
-                lstListsInsideMSBT.Sorted = true;
-                lstListsInsideMSBT.Sorted = false;
+                lstListsInsideMsbt.Sorted = true;
+                lstListsInsideMsbt.Sorted = false;
 
-                var MsbtTextMatchData = lstListsInsideMSBT.Items.IndexOf(txtMSBTListName.Text);
+                var MsbtTextMatchData = lstListsInsideMsbt.Items.IndexOf(txtMsbtListName.Text);
 
                 MSBT_Data.MSBT_All_Data.Text.Insert(MsbtTextMatchData, "テキスト</End>");
                 MSBT_Data.MSBT_All_Data.Item.Insert(MsbtTextMatchData, new ATR1.AttributeData(0x1, 0x0, 0x0, 0x0, 0x0, 0xFF, 0xFF, 0x00));
@@ -364,7 +364,7 @@ namespace MSBT_Editor
                 {
                     //Debugger.HashTxt("lbl newindex" + lbl1_newindex.ToString());
                     LBL1.NameOffsetList.Insert(lbl1_newindex, 0);
-                    LBL1.NameList.Insert(lbl1_newindex, txtMSBTListName.Text);
+                    LBL1.NameList.Insert(lbl1_newindex, txtMsbtListName.Text);
                     LBL1.HashSkipList.Insert(lbl1_newindex, 0x00000001);
                     LBL1.BeginEntryAdressList.Insert(lbl1_newindex, 0);
                 }
@@ -372,7 +372,7 @@ namespace MSBT_Editor
                 //BattanKing002_Flow000
                 //ScenarioName_RedBlueExGalaxy3
                 //MSBFファイルのフロータイプ1の対象MSBTの挿入以降の番号に+1する
-                if (lstListsInsideFLW2.Items.Count == 0 || lstListsInsideFEN1.Items.Count == 0) return;
+                if (lstListsInsideFlw2.Items.Count == 0 || lstListsInsideFen1.Items.Count == 0) return;
                 FLW2 flw2 = new FLW2();
                 List<FLW2.flw2_item> copyitem = new List<FLW2.flw2_item>(flw2.Item);
                 foreach (var flw2item in copyitem.Select((Value, Index) => (Value, Index)))
@@ -389,7 +389,7 @@ namespace MSBT_Editor
             else
             {
                 //初回にデータを入れる場合
-                if (txtMSBTListName.Text != "")
+                if (txtMsbtListName.Text != "")
                 {
                     LBL1 lbl1 = new LBL1();
                     lbl1.EntrySize = 101;
@@ -409,7 +409,7 @@ namespace MSBT_Editor
                     MSBT_Data.MSBT_All_Data = msbtdatalist;
 
                     //リストボックス1とMSBTのデータに追加する
-                    lstListsInsideMSBT.Items.Add(txtMSBTListName.Text);
+                    lstListsInsideMsbt.Items.Add(txtMsbtListName.Text);
                     if (Properties.Settings.Default.言語 == "EN")
                         MSBT_Data.MSBT_All_Data.Text.Add("Default Text</End>");
                     else
@@ -419,25 +419,25 @@ namespace MSBT_Editor
 
                     //ラベル情報を追加する
                     LBL1.NameOffsetList.Add(0);
-                    LBL1.NameList.Add(txtMSBTListName.Text);
+                    LBL1.NameList.Add(txtMsbtListName.Text);
                     LBL1.HashSkipList.Add(1);
                     LBL1.BeginEntryAdressList.Add(0);
                 }
             }
         }
 
-        private void BtnDeleteMSBTList_Click(object sender, EventArgs e)
+        private void BtnDeleteMsbtList_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count != 0 && (MSBT_Data.MSBT_All_Data.Item.Count != 0) && MSBT_Data.MSBT_All_Data.Text.Count != 0)
+            if (lstListsInsideMsbt.Items.Count != 0 && (MSBT_Data.MSBT_All_Data.Item.Count != 0) && MSBT_Data.MSBT_All_Data.Text.Count != 0)
             {
                 var array_list_name = LBL1.NameList.ToArray();
-                var array_search = Array.IndexOf(array_list_name, lstListsInsideMSBT.SelectedItem.ToString());
+                var array_search = Array.IndexOf(array_list_name, lstListsInsideMsbt.SelectedItem.ToString());
                 ////Console.WriteLine("array_search -1");
                 //if (array_search == -1) return;
                 //Console.WriteLine("array_search -1以外");
-                MSBT_Data.MSBT_All_Data.Item.RemoveRange(lstListsInsideMSBT.SelectedIndex, 1);
-                MSBT_Data.MSBT_All_Data.Text.RemoveRange(lstListsInsideMSBT.SelectedIndex, 1);
-                MSBT_Data.Atr1SpecialText.RemoveRange(lstListsInsideMSBT.SelectedIndex, 1);
+                MSBT_Data.MSBT_All_Data.Item.RemoveRange(lstListsInsideMsbt.SelectedIndex, 1);
+                MSBT_Data.MSBT_All_Data.Text.RemoveRange(lstListsInsideMsbt.SelectedIndex, 1);
+                MSBT_Data.Atr1SpecialText.RemoveRange(lstListsInsideMsbt.SelectedIndex, 1);
 
 
                 //ハッシュスキップされている値の場合
@@ -459,24 +459,24 @@ namespace MSBT_Editor
                 //LBL1.list_name.RemoveRange(array_search , 1);
                 //LBL1.unknown.RemoveRange(array_search, 1);
                 //LBL1.unknownpos.RemoveRange(array_search, 1);
-                var listselect = lstListsInsideMSBT.SelectedIndex;
-                lstListsInsideMSBT.Items.RemoveAt(listselect);
+                var listselect = lstListsInsideMsbt.SelectedIndex;
+                lstListsInsideMsbt.Items.RemoveAt(listselect);
             }
         }
 
-        private void TxtLBL1EntrySize_TextChanged(object sender, EventArgs e)
+        private void TxtLbl1EntrySize_TextChanged(object sender, EventArgs e)
         {
             _ = new LBL1
             {
-                EntrySize = Int32.Parse(txtLBL1EntrySize.Text)
+                EntrySize = Int32.Parse(txtLbl1EntrySize.Text)
             };
         }
 
-        private void TxtATR1EntrySize_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1EntrySize_TextChanged(object sender, EventArgs e)
         {
             _ = new ATR1
             {
-                EntrySize = Int32.Parse(txtATR1EntrySize.Text)
+                EntrySize = Int32.Parse(txtAtr1EntrySize.Text)
             };
         }
 
@@ -485,8 +485,8 @@ namespace MSBT_Editor
             var ColorTag = new MSBT_TagData.TagInsertModified(new MSBT_TagData.ColorTag())
             {
                 TagComboBox = cmbColorTag,
-                MsbtListBox = lstListsInsideMSBT,
-                MsbtTextBox = txtMSBTText
+                MsbtListBox = lstListsInsideMsbt,
+                MsbtTextBox = txtMsbtText
             };
             ColorTag.ToMsbtTextBoxInsert();
         }
@@ -496,8 +496,8 @@ namespace MSBT_Editor
             var LineControlTag = new MSBT_TagData.TagInsertModified(new MSBT_TagData.LineControlTag())
             {
                 TagComboBox = cmbLineControlTag,
-                MsbtListBox = lstListsInsideMSBT,
-                MsbtTextBox = txtMSBTText
+                MsbtListBox = lstListsInsideMsbt,
+                MsbtTextBox = txtMsbtText
             };
             LineControlTag.ToMsbtTextBoxInsert();
         }
@@ -507,8 +507,8 @@ namespace MSBT_Editor
             var FontSizeTag = new MSBT_TagData.TagInsertModified(new MSBT_TagData.FontSizeTag())
             {
                 TagComboBox = cmbFontSizeTag,
-                MsbtListBox = lstListsInsideMSBT,
-                MsbtTextBox = txtMSBTText
+                MsbtListBox = lstListsInsideMsbt,
+                MsbtTextBox = txtMsbtText
             };
             FontSizeTag.ToMsbtTextBoxInsert();
         }
@@ -519,20 +519,20 @@ namespace MSBT_Editor
             var CenterTag = new MSBT_TagData.TagInsertModified(new MSBT_TagData.CenterTag())
             {
                 TagComboBox = cmbCenterTag,
-                MsbtListBox = lstListsInsideMSBT,
-                MsbtTextBox = txtMSBTText
+                MsbtListBox = lstListsInsideMsbt,
+                MsbtTextBox = txtMsbtText
             };
             CenterTag.ToMsbtTextBoxInsert();
         }
 
         private void BtnInsertRubiTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             if (txtRubiTagRubiCount.Text == "" || txtRubiTagKanjiCount.Text == "") return;
             string furigana = txtRubiTagRubiCount.Text;
             string kanji = txtRubiTagKanjiCount.Text;
             string tag = "<Rubi=\"" + furigana + "\" Target=\"" + kanji + "\">";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void TxtRubiTagRubiCount_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyDecChar(e);
@@ -542,39 +542,39 @@ namespace MSBT_Editor
 
         private void BtnInsertTimerTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             if (txtTimerTagDelayTime.Text == "") return;
             string time = txtTimerTagDelayTime.Text;
             string tag = "</Timer=\"" + time + "\">";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertPlayerCharacterTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</PlayCharacter>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertVariableInt3DigitsTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</ReferenceValue1>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertResultGalaxyNameTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</ResultGalaxyName>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertResultScenarioNameTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</ResultScenarioName>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertCharacterIconTag_Click(object sender, EventArgs e)
@@ -654,154 +654,154 @@ namespace MSBT_Editor
                     "<Icon=\"Kinopio\">",
                     "<Icon=\"BronzeComet\">", };
 
-                Calculation_System.TextBoxTagAdder(lstListsInsideMSBT, txtMSBTText, cmbCharacterIconTag, IconTag);
+                Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbCharacterIconTag, IconTag);
             }
             else
             {
                 string[] IconTag = { "<Icon=\"Peach\">", "<Icon=\"Koopa\">", "<Icon=\"Kinopio\">", "<Icon=\"Mario\">", "<Icon=\"Mario2\">", "<Icon=\"Tico\">", "<Icon=\"Yoshi\">", "<Icon=\"HarapekoTico\">", "<Icon=\"Luigi\">", "<Icon=\"MasterTico\">", "<Icon=\"Columa\">", "<Icon=\"Begoman\">", "<Icon=\"Kuribo\">", "<Icon=\"Star Bunny\">" };
-                Calculation_System.TextBoxTagAdder(lstListsInsideMSBT, txtMSBTText, cmbCharacterIconTag, IconTag);
+                Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbCharacterIconTag, IconTag);
             }
         }
 
         private void BtnInsertObjectIconTag_Click(object sender, EventArgs e)
         {
             string[] IconTag = { "<Icon=\"CometMedal\">", "<Icon=\"Coins\">", "<Icon=\"Starbit\">", "<Icon=\"StarPiece\">", "<Icon=\"PurpleStarbit\">", "<Icon=\"SilverStar\">", "<Icon=\"Star\">", "<Icon=\"GrandStar\">", "<Icon=\"BronzeStar\">", "<Icon=\"Coin\">", "<Icon=\"PurpleCoin\">", "<Icon=\"1UPMushroom\">", "<Icon=\"LifeUpMushroom\">", "<Icon=\"BlueStar\">", "<Icon=\"StarRing\">", "<Icon=\"Flower\">", "<Icon=\"Coconut\">", "<Icon=\"BlueChip\">", "<Icon=\"BlueFruit\">", "<Icon=\"CheckPointFlag\">", "<Icon=\"GrandBronzeStar\">" };
-            Calculation_System.TextBoxTagAdder(lstListsInsideMSBT, txtMSBTText, cmbObjectIconTag, IconTag);
+            Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbObjectIconTag, IconTag);
         }
 
         private void BtnInsertOthersIconTag_Click(object sender, EventArgs e)
         {
             string[] IconTag = { "<Icon=\"Pointer\">", "<Icon=\"PointerYellow\">", "<Icon=\"PointerHand\">", "<Icon=\"WiiMote\">", "<Icon=\"AButton\">", "<Icon=\"BButton\">", "<Icon=\"CButton\">", "<Icon=\"ZButton\">", "<Icon=\"DPad\">", "<Icon=\"DPadDown\">", "<Icon=\"DPadUp\">", "<Icon=\"JoyStick\">", "<Icon=\"Nunchuck\">", "<Icon=\"Aim\">", "<Icon=\"MButton\">", "<Icon=\"PButton\">", "<Icon=\"XIcon\">", "<Icon=\"GreenComet\">", "<Icon=\"SilverCrown\">", "<Icon=\"SilverCrownwJewel\">", "<Icon=\"GoldCrown\">", "<Icon=\"Letter\">", "<Icon=\"ArrowDown\">", "<Icon=\"StopWatch\">", "<Icon=\"1Button\">", "<Icon=\"2Button\">", "<Icon=\"HomeButton\">", "<Icon=\"PointerGrip\">", "<Icon=\"PointerNonGrip\">", "<Icon=\"QuestionMark\">", "<Icon=\"YellowComet\">", "<Icon=\"GreenQuestionMark\">", "<Icon=\"EmptyStar\">", "<Icon=\"EmptyCometMedal\">", "<Icon=\"EmptyStarComet\">", "<Icon=\"HiddenStar\">", "<Icon=\"BronzeComet\">" };
-            Calculation_System.TextBoxTagAdder(lstListsInsideMSBT, txtMSBTText, cmbOthersIconTag, IconTag);
+            Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbOthersIconTag, IconTag);
         }
 
         private void BtnInsertVariableInt4DigitsTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</ReferenceValue2>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertVariableInt5DigitsTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</ReferenceValue3>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertHourTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</Hour>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertMinuteTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</Minutes>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertSecondTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</Seconds>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertNumbersBelowDecimalPoint_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</AfterTheDecimalPoint>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnReleaseDebugTextFile_Click(object sender, EventArgs e)
         {
-            if (stbOpenedMSBTName.Text == " ") return;
-            if (textBox13.Text == "") return;
+            if (stbOpenedMsbtName.Text == " ") return;
+            if (txtFlw2DebugHex.Text == "") return;
             string appPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
-            string msbtname = Path.GetFileNameWithoutExtension(stbOpenedMSBTName.Text);
+            string msbtname = Path.GetFileNameWithoutExtension(stbOpenedMsbtName.Text);
             string textpath = Path.Combine(Path.GetDirectoryName(appPath), msbtname + ".txt");
             //Console.WriteLine(textpath);
 
-            File.WriteAllText(textpath, textBox13.Text);
+            File.WriteAllText(textpath, txtFlw2DebugHex.Text);
         }
 
-        private void LstListsInsideFLW2_SelectedIndexChanged(object sender, EventArgs e)
+        private void LstListsInsideFlw2_SelectedIndexChanged(object sender, EventArgs e)
         {
-            this.txtFLW2BranchTrue.TextChanged -= new EventHandler(this.TxtFLW2BranchTrue_TextChanged);
-            this.txtFLW2BranchFalse.TextChanged -= new EventHandler(this.TxtFLW2BranchFalse_TextChanged);
+            this.txtFlw2BranchTrue.TextChanged -= new EventHandler(this.TxtFlw2BranchTrue_TextChanged);
+            this.txtFlw2BranchFalse.TextChanged -= new EventHandler(this.TxtFlw2BranchFalse_TextChanged);
 
-            if (lstListsInsideFLW2.Items.Count == 0) return;
-            var index = lstListsInsideFLW2.SelectedIndex;
+            if (lstListsInsideFlw2.Items.Count == 0) return;
+            var index = lstListsInsideFlw2.SelectedIndex;
             if (index == -1) index = 0;
             FLW2 flw2 = new FLW2();
             //Console.WriteLine(index);
-            txtFLW2FlowType.Text = flw2.Item[index].TypeCheck.ToString("X4");
-            txtFLW2Padding.Text = flw2.Item[index].Unknown1.ToString("X4");
-            txtFLW2Arg1.Text = flw2.Item[index].Unknown2.ToString("X4");
-            txtFLW2Arg2.Text = flw2.Item[index].Unknown3.ToString("X4");
-            txtFLW2Arg3.Text = flw2.Item[index].Unknown4.ToString("X4");
-            txtFLW2Arg4.Text = flw2.Item[index].Unknown5.ToString("X4");
+            txtFlw2FlowType.Text = flw2.Item[index].TypeCheck.ToString("X4");
+            txtFlw2Padding.Text = flw2.Item[index].Unknown1.ToString("X4");
+            txtFlw2Arg1.Text = flw2.Item[index].Unknown2.ToString("X4");
+            txtFlw2Arg2.Text = flw2.Item[index].Unknown3.ToString("X4");
+            txtFlw2Arg3.Text = flw2.Item[index].Unknown4.ToString("X4");
+            txtFlw2Arg4.Text = flw2.Item[index].Unknown5.ToString("X4");
 
             switch (flw2.Item[index].TypeCheck.ToString("X4"))
             {
                 case "0001":
-                    lblFLW2Arg1.Text = "グループ番号";
-                    lblFLW2Arg2.Text = "Msbtテキストlist番号";
-                    lblFLW2Arg3.Text = "FLW2オフセット";
-                    lblFLW2Arg4.Text = "不明5";
+                    lblFlw2Arg1.Text = "グループ番号";
+                    lblFlw2Arg2.Text = "Msbtテキストlist番号";
+                    lblFlw2Arg3.Text = "FLW2オフセット";
+                    lblFlw2Arg4.Text = "不明5";
                     if (Properties.Settings.Default.言語 == "日本語") break;
-                    lblFLW2Arg1.Text = "Group number";
-                    lblFLW2Arg2.Text = "MSBT Entry";
-                    lblFLW2Arg3.Text = "Next Flow";
-                    lblFLW2Arg4.Text = "Unknown5";
+                    lblFlw2Arg1.Text = "Group number";
+                    lblFlw2Arg2.Text = "MSBT Entry";
+                    lblFlw2Arg3.Text = "Next Flow";
+                    lblFlw2Arg4.Text = "Unknown5";
                     break;
                 case "0002":
-                    lblFLW2Arg1.Text = "0002固定";
-                    lblFLW2Arg2.Text = "不明3";
-                    lblFLW2Arg3.Text = "不明4";
-                    lblFLW2Arg4.Text = "分岐先オフセット";
+                    lblFlw2Arg1.Text = "0002固定";
+                    lblFlw2Arg2.Text = "不明3";
+                    lblFlw2Arg3.Text = "不明4";
+                    lblFlw2Arg4.Text = "分岐先オフセット";
                     if (Properties.Settings.Default.言語 == "日本語") break;
-                    lblFLW2Arg1.Text = "Always 0002";
-                    lblFLW2Arg2.Text = "Condition ID";
-                    lblFLW2Arg3.Text = "Unknown4";
-                    lblFLW2Arg4.Text = "Unknown5";
+                    lblFlw2Arg1.Text = "Always 0002";
+                    lblFlw2Arg2.Text = "Condition ID";
+                    lblFlw2Arg3.Text = "Unknown4";
+                    lblFlw2Arg4.Text = "Unknown5";
                     break;
                 case "0004":
-                    lblFLW2Arg1.Text = "ジャンプ先";
-                    lblFLW2Arg2.Text = "不明3";
-                    lblFLW2Arg3.Text = "不明4";
-                    lblFLW2Arg4.Text = "不明5";
+                    lblFlw2Arg1.Text = "ジャンプ先";
+                    lblFlw2Arg2.Text = "不明3";
+                    lblFlw2Arg3.Text = "不明4";
+                    lblFlw2Arg4.Text = "不明5";
                     if (Properties.Settings.Default.言語 == "日本語") break;
-                    lblFLW2Arg1.Text = "Next Flow ID";
-                    lblFLW2Arg2.Text = "Unknown3";
-                    lblFLW2Arg3.Text = "Unknown4";
-                    lblFLW2Arg4.Text = "Unknown5";
+                    lblFlw2Arg1.Text = "Next Flow ID";
+                    lblFlw2Arg2.Text = "Unknown3";
+                    lblFlw2Arg3.Text = "Unknown4";
+                    lblFlw2Arg4.Text = "Unknown5";
                     break;
                 case "0003":
-                    lblFLW2Arg1.Text = "イベント番号";
-                    lblFLW2Arg2.Text = "FLWオフセット";
-                    lblFLW2Arg3.Text = "不明4";
-                    lblFLW2Arg4.Text = "不明5";
+                    lblFlw2Arg1.Text = "イベント番号";
+                    lblFlw2Arg2.Text = "FLWオフセット";
+                    lblFlw2Arg3.Text = "不明4";
+                    lblFlw2Arg4.Text = "不明5";
                     if (Properties.Settings.Default.言語 == "日本語") break;
-                    lblFLW2Arg1.Text = "Event ID";
-                    lblFLW2Arg2.Text = "Next Flow";
-                    lblFLW2Arg3.Text = "Unknown4";
-                    lblFLW2Arg4.Text = "Unknown5";
+                    lblFlw2Arg1.Text = "Event ID";
+                    lblFlw2Arg2.Text = "Next Flow";
+                    lblFlw2Arg3.Text = "Unknown4";
+                    lblFlw2Arg4.Text = "Unknown5";
                     break;
                 default:
-                    lblFLW2Arg1.Text = "不明2";
-                    lblFLW2Arg2.Text = "不明3";
-                    lblFLW2Arg3.Text = "不明4";
-                    lblFLW2Arg4.Text = "不明5";
+                    lblFlw2Arg1.Text = "不明2";
+                    lblFlw2Arg2.Text = "不明3";
+                    lblFlw2Arg3.Text = "不明4";
+                    lblFlw2Arg4.Text = "不明5";
                     if (Properties.Settings.Default.言語 == "日本語") break;
-                    lblFLW2Arg1.Text = "Unknown2";
-                    lblFLW2Arg2.Text = "Unknown3";
-                    lblFLW2Arg3.Text = "Unknown4";
-                    lblFLW2Arg4.Text = "Unknown5";
+                    lblFlw2Arg1.Text = "Unknown2";
+                    lblFlw2Arg2.Text = "Unknown3";
+                    lblFlw2Arg3.Text = "Unknown4";
+                    lblFlw2Arg4.Text = "Unknown5";
                     break;
 
             }
@@ -811,75 +811,75 @@ namespace MSBT_Editor
 
             if (blnc != bnc)
             {
-                lblFLW2ListSelectIndex.Text = "0x" + lstListsInsideFLW2.SelectedIndex.ToString("X");
-                this.txtFLW2BranchTrue.TextChanged += new EventHandler(this.TxtFLW2BranchTrue_TextChanged);
-                this.txtFLW2BranchFalse.TextChanged += new EventHandler(this.TxtFLW2BranchFalse_TextChanged);
+                lblFlw2ListSelectIndex.Text = "0x" + lstListsInsideFlw2.SelectedIndex.ToString("X");
+                this.txtFlw2BranchTrue.TextChanged += new EventHandler(this.TxtFlw2BranchTrue_TextChanged);
+                this.txtFlw2BranchFalse.TextChanged += new EventHandler(this.TxtFlw2BranchFalse_TextChanged);
                 return;
             }
             if (-1 == flw2.Branch_List_No.IndexOf(index))
             {
 
-                txtFLW2BranchTrue.Text = "";
-                txtFLW2BranchFalse.Text = "";
-                lblFLW2ListSelectIndex.Text = "0x" + lstListsInsideFLW2.SelectedIndex.ToString("X");
-                this.txtFLW2BranchTrue.TextChanged += new EventHandler(this.TxtFLW2BranchTrue_TextChanged);
-                this.txtFLW2BranchFalse.TextChanged += new EventHandler(this.TxtFLW2BranchFalse_TextChanged);
+                txtFlw2BranchTrue.Text = "";
+                txtFlw2BranchFalse.Text = "";
+                lblFlw2ListSelectIndex.Text = "0x" + lstListsInsideFlw2.SelectedIndex.ToString("X");
+                this.txtFlw2BranchTrue.TextChanged += new EventHandler(this.TxtFlw2BranchTrue_TextChanged);
+                this.txtFlw2BranchFalse.TextChanged += new EventHandler(this.TxtFlw2BranchFalse_TextChanged);
                 return;
             }
             textBox27.AppendText(Environment.NewLine + "selectlist");
             textBox27.AppendText(Environment.NewLine + flw2.Branch_No[flw2.Branch_List_No.IndexOf(index)].ToString("X4") + "___" + flw2.Branch_List_No.IndexOf(index));
 
-            txtFLW2BranchTrue.Text = flw2.Branch_No[(flw2.Branch_List_No.IndexOf(index) * 2)].ToString("X4");
-            txtFLW2BranchFalse.Text = flw2.Branch_No[(flw2.Branch_List_No.IndexOf(index) * 2) + 1].ToString("X4");
+            txtFlw2BranchTrue.Text = flw2.Branch_No[(flw2.Branch_List_No.IndexOf(index) * 2)].ToString("X4");
+            txtFlw2BranchFalse.Text = flw2.Branch_No[(flw2.Branch_List_No.IndexOf(index) * 2) + 1].ToString("X4");
 
-            lblFLW2ListSelectIndex.Text = "0x" + lstListsInsideFLW2.SelectedIndex.ToString("X");
-            this.txtFLW2BranchTrue.TextChanged += new EventHandler(this.TxtFLW2BranchTrue_TextChanged);
-            this.txtFLW2BranchFalse.TextChanged += new EventHandler(this.TxtFLW2BranchFalse_TextChanged);
+            lblFlw2ListSelectIndex.Text = "0x" + lstListsInsideFlw2.SelectedIndex.ToString("X");
+            this.txtFlw2BranchTrue.TextChanged += new EventHandler(this.TxtFlw2BranchTrue_TextChanged);
+            this.txtFlw2BranchFalse.TextChanged += new EventHandler(this.TxtFlw2BranchFalse_TextChanged);
         }
 
-        private void TxtFLW2FlowType_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2FlowType_TextChanged(object sender, EventArgs e)
         {
-            this.lstListsInsideFLW2.SelectedIndexChanged -= new EventHandler(this.LstListsInsideFLW2_SelectedIndexChanged);
-            FLW2.FLW2_Item_Change(lstListsInsideFLW2, txtFLW2FlowType);
-            this.lstListsInsideFLW2.SelectedIndexChanged += new EventHandler(this.LstListsInsideFLW2_SelectedIndexChanged);
+            this.lstListsInsideFlw2.SelectedIndexChanged -= new EventHandler(this.LstListsInsideFlw2_SelectedIndexChanged);
+            FLW2.FLW2_Item_Change(lstListsInsideFlw2, txtFlw2FlowType);
+            this.lstListsInsideFlw2.SelectedIndexChanged += new EventHandler(this.LstListsInsideFlw2_SelectedIndexChanged);
         }
 
-        private void TxtFLW2Padding_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2Padding_TextChanged(object sender, EventArgs e)
         {
-            this.lstListsInsideFLW2.SelectedIndexChanged -= new EventHandler(this.LstListsInsideFLW2_SelectedIndexChanged);
-            FLW2.FLW2_Item_Change(lstListsInsideFLW2, txtFLW2Padding);
-            this.lstListsInsideFLW2.SelectedIndexChanged += new EventHandler(this.LstListsInsideFLW2_SelectedIndexChanged);
+            this.lstListsInsideFlw2.SelectedIndexChanged -= new EventHandler(this.LstListsInsideFlw2_SelectedIndexChanged);
+            FLW2.FLW2_Item_Change(lstListsInsideFlw2, txtFlw2Padding);
+            this.lstListsInsideFlw2.SelectedIndexChanged += new EventHandler(this.LstListsInsideFlw2_SelectedIndexChanged);
         }
 
-        private void TxtFLW2Arg1_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2Arg1_TextChanged(object sender, EventArgs e)
         {
-            FLW2.FLW2_Item_Change(lstListsInsideFLW2, txtFLW2Arg1);
+            FLW2.FLW2_Item_Change(lstListsInsideFlw2, txtFlw2Arg1);
         }
 
-        private void TxtFLW2Arg2_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2Arg2_TextChanged(object sender, EventArgs e)
         {
-            FLW2.FLW2_Item_Change(lstListsInsideFLW2, txtFLW2Arg2);
+            FLW2.FLW2_Item_Change(lstListsInsideFlw2, txtFlw2Arg2);
         }
 
-        private void TxtFLW2Arg3_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2Arg3_TextChanged(object sender, EventArgs e)
         {
-            FLW2.FLW2_Item_Change(lstListsInsideFLW2, txtFLW2Arg3);
+            FLW2.FLW2_Item_Change(lstListsInsideFlw2, txtFlw2Arg3);
         }
 
-        private void TxtFLW2Arg4_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2Arg4_TextChanged(object sender, EventArgs e)
         {
-            FLW2.FLW2_Item_Change(lstListsInsideFLW2, txtFLW2Arg4);
+            FLW2.FLW2_Item_Change(lstListsInsideFlw2, txtFlw2Arg4);
         }
 
-        private void TxtFLW2BranchTrue_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2BranchTrue_TextChanged(object sender, EventArgs e)
         {
             textBox27.AppendText(Environment.NewLine + "25text");
-            FLW2.FLW2_FlowType2_Branch(lstListsInsideFLW2, txtFLW2BranchTrue);
+            FLW2.FLW2_FlowType2_Branch(lstListsInsideFlw2, txtFlw2BranchTrue);
         }
 
-        private void TxtFLW2BranchFalse_TextChanged(object sender, EventArgs e)
+        private void TxtFlw2BranchFalse_TextChanged(object sender, EventArgs e)
         {
-            FLW2.FLW2_FlowType2_Branch(lstListsInsideFLW2, txtFLW2BranchFalse);
+            FLW2.FLW2_FlowType2_Branch(lstListsInsideFlw2, txtFlw2BranchFalse);
         }
 
         private void Form1_DragDrop(object sender, DragEventArgs e)
@@ -937,37 +937,37 @@ namespace MSBT_Editor
 
         }
 
-        private void TxtFEN1Arg0_TextChanged(object sender, EventArgs e)
+        private void TxtFen1Arg0_TextChanged(object sender, EventArgs e)
         {
-            FEN1.FEN1_Item_Change(lstListsInsideFEN1, txtFEN1Arg0);
+            FEN1.FEN1_Item_Change(lstListsInsideFen1, txtFen1Arg0);
         }
 
-        private void TxtFEN1StartIndex_TextChanged(object sender, EventArgs e)
+        private void TxtFen1StartIndex_TextChanged(object sender, EventArgs e)
         {
-            FEN1.FEN1_Item_Change(lstListsInsideFEN1, txtFEN1StartIndex);
+            FEN1.FEN1_Item_Change(lstListsInsideFen1, txtFen1StartIndex);
         }
 
-        private void LstListsInsideFEN1_SelectedIndexChanged(object sender, EventArgs e)
+        private void LstListsInsideFen1_SelectedIndexChanged(object sender, EventArgs e)
         {
-            this.txtFEN1Arg0.TextChanged -= new EventHandler(this.TxtFEN1Arg0_TextChanged);
-            this.txtFEN1StartIndex.TextChanged -= new EventHandler(this.TxtFEN1StartIndex_TextChanged);
+            this.txtFen1Arg0.TextChanged -= new EventHandler(this.TxtFen1Arg0_TextChanged);
+            this.txtFen1StartIndex.TextChanged -= new EventHandler(this.TxtFen1StartIndex_TextChanged);
 
-            if (lstListsInsideFEN1.Items.Count == 0) return;
-            var index = lstListsInsideFEN1.SelectedIndex;
+            if (lstListsInsideFen1.Items.Count == 0) return;
+            var index = lstListsInsideFen1.SelectedIndex;
             if (index == -1) index = 0;
 
             FEN1 fen1 = new FEN1();
             var hashes = Calculation_System.MSBT_Hash(fen1.Item2[index].tagname, 0x3B);
 
             //textBox28.Text = fen1.Item1[index].tagflag.ToString("X8");
-            txtFEN1Arg0.Text = fen1.Hashes[index].tagflag.ToString("X8");
-            txtFEN1StartIndex.Text = fen1.Item2[index].tagnum.ToString("X8");
+            txtFen1Arg0.Text = fen1.Hashes[index].tagflag.ToString("X8");
+            txtFen1StartIndex.Text = fen1.Item2[index].tagnum.ToString("X8");
 
-            if (lstListsInsideFLW2.Items.Count > fen1.Item2[index].tagnum) lstListsInsideFLW2.SelectedIndex = fen1.Item2[index].tagnum;
+            if (lstListsInsideFlw2.Items.Count > fen1.Item2[index].tagnum) lstListsInsideFlw2.SelectedIndex = fen1.Item2[index].tagnum;
 
-            lblFEN1ListSelectIndex.Text = "0x" + lstListsInsideFEN1.SelectedIndex.ToString("X");
-            this.txtFEN1Arg0.TextChanged += new EventHandler(this.TxtFEN1Arg0_TextChanged);
-            this.txtFEN1StartIndex.TextChanged += new EventHandler(this.TxtFEN1StartIndex_TextChanged);
+            lblFen1ListSelectIndex.Text = "0x" + lstListsInsideFen1.SelectedIndex.ToString("X");
+            this.txtFen1Arg0.TextChanged += new EventHandler(this.TxtFen1Arg0_TextChanged);
+            this.txtFen1StartIndex.TextChanged += new EventHandler(this.TxtFen1StartIndex_TextChanged);
 
         }
 
@@ -976,41 +976,39 @@ namespace MSBT_Editor
 
         }
 
-        private void TxtFEN1ListName_TextChanged(object sender, EventArgs e)
+        private void TxtFen1ListName_TextChanged(object sender, EventArgs e)
         {
 
         }
 
-        private void BtnAddFLW2List_Click(object sender, EventArgs e)
+        private void BtnAddFlw2List_Click(object sender, EventArgs e)
         {
             FLW2 flw2 = new FLW2();
-            if (lstListsInsideFLW2.Items.Count != 0)
+            if (lstListsInsideFlw2.Items.Count != 0)
             {
-                lstListsInsideFLW2.Items.Add(Langage.FLW2_List_Langage(4));
+                lstListsInsideFlw2.Items.Add(Langage.FLW2_List_Langage(4));
                 flw2.Item.Add(new FLW2.flw2_item(4, 0, 0, 0, 0, 0));
-                lstListsInsideFLW2.EndUpdate();
+                lstListsInsideFlw2.EndUpdate();
             }
             else
             {
-                lstListsInsideFLW2.Items.Add(Langage.FLW2_List_Langage(4));
+                lstListsInsideFlw2.Items.Add(Langage.FLW2_List_Langage(4));
                 flw2.Item = new List<FLW2.flw2_item>();
                 flw2.Item.Add(new FLW2.flw2_item(4, 0, 0, 0, 0, 0));
                 flw2.Branch_List_No = new List<int>();
                 flw2.Branch_No = new List<short>();
-                lstListsInsideFLW2.EndUpdate();
+                lstListsInsideFlw2.EndUpdate();
             }
         }
 
-        private void BtnDeleteFLW2List_Click(object sender, EventArgs e)
+        private void BtnDeleteFlw2List_Click(object sender, EventArgs e)
         {
             FLW2 flw2 = new FLW2();
 
-            if (lstListsInsideFLW2.Items.Count != 0 && (flw2.Item.Count != 0) && (flw2.Branch_List_No != null) && (flw2.Branch_No != null))
+            if (lstListsInsideFlw2.Items.Count != 0 && (flw2.Item.Count != 0) && (flw2.Branch_List_No != null) && (flw2.Branch_No != null))
             {
-
-
-                var listselect = lstListsInsideFLW2.SelectedIndex;
-                lstListsInsideFLW2.Items.RemoveAt(listselect);
+                var listselect = lstListsInsideFlw2.SelectedIndex;
+                lstListsInsideFlw2.Items.RemoveAt(listselect);
                 if (flw2.Item[listselect].TypeCheck == 2)
                 {
                     flw2.Branch_No.RemoveAt((flw2.Branch_List_No.IndexOf(listselect)) * 2);
@@ -1020,22 +1018,22 @@ namespace MSBT_Editor
             }
         }
 
-        private void BtnAddFEN1List_Click(object sender, EventArgs e)
+        private void BtnAddFen1List_Click(object sender, EventArgs e)
         {
             FEN1 fen1 = new FEN1();
             FLW2 flw2 = new FLW2();
 
             short list2count = 0;
-            if (lstListsInsideFEN1.Items.Count != 0)
+            if (lstListsInsideFen1.Items.Count != 0)
             {
                 list2count = (short)fen1.Item2.Count;
-                if (txtFEN1ListName.Text != "")
+                if (txtFen1ListName.Text != "")
                 {
-                    lstListsInsideFEN1.Items.Add(txtFEN1ListName.Text);
+                    lstListsInsideFen1.Items.Add(txtFen1ListName.Text);
                     fen1.Item1.Add(new FEN1.Element(1, 0));
                     var item2count = fen1.Item2.Count;
-                    fen1.Item2.Add(new FEN1.ElementTag(txtFEN1ListName.Text, lstListsInsideFLW2.Items.Count));
-                    var hash = Calculation_System.MSBT_Hash(txtFEN1ListName.Text, 0x3B);
+                    fen1.Item2.Add(new FEN1.ElementTag(txtFen1ListName.Text, lstListsInsideFlw2.Items.Count));
+                    var hash = Calculation_System.MSBT_Hash(txtFen1ListName.Text, 0x3B);
                     fen1.Hashes.Add(new FEN1.Hash_And_Unknown(1, hash));
                     //treeView1.Nodes.Add(textBox31.Text);
 
@@ -1060,18 +1058,18 @@ namespace MSBT_Editor
             }
             else
             {
-                if (txtFEN1ListName.Text != "")
+                if (txtFen1ListName.Text != "")
                 {
                     fen1.Item1 = new List<FEN1.Element>();
                     fen1.Item2 = new List<FEN1.ElementTag>();
                     fen1.Hashes = new List<FEN1.Hash_And_Unknown>();
 
 
-                    lstListsInsideFEN1.Items.Add(txtFEN1ListName.Text);
+                    lstListsInsideFen1.Items.Add(txtFen1ListName.Text);
                     fen1.Item1.Add(new FEN1.Element(1, 0));
-                    fen1.Item2.Add(new FEN1.ElementTag(txtFEN1ListName.Text, lstListsInsideFLW2.Items.Count));
+                    fen1.Item2.Add(new FEN1.ElementTag(txtFen1ListName.Text, lstListsInsideFlw2.Items.Count));
 
-                    var hash = Calculation_System.MSBT_Hash(txtFEN1ListName.Text, 0x3B);
+                    var hash = Calculation_System.MSBT_Hash(txtFen1ListName.Text, 0x3B);
                     fen1.Hashes.Add(new FEN1.Hash_And_Unknown(1, hash));
                     //treeView1.Nodes.Add(textBox31.Text);
 
@@ -1095,11 +1093,11 @@ namespace MSBT_Editor
             }
         }
 
-        private void BtnDeleteFEN1List_Click(object sender, EventArgs e)
+        private void BtnDeleteFen1List_Click(object sender, EventArgs e)
         {
             FEN1 fen1 = new FEN1();
 
-            if (lstListsInsideFEN1.Items.Count != 0 && (fen1.Item1.Count != 0) && (fen1.Item2.Count != 0) && (fen1.Hashes.Count != 0))
+            if (lstListsInsideFen1.Items.Count != 0 && (fen1.Item1.Count != 0) && (fen1.Item2.Count != 0) && (fen1.Hashes.Count != 0))
             {
                 Console.WriteLine(fen1.Item1.Count());
                 Console.WriteLine(fen1.Item2.Count());
@@ -1107,18 +1105,18 @@ namespace MSBT_Editor
 
 
 
-                var listselect = lstListsInsideFEN1.SelectedIndex;
+                var listselect = lstListsInsideFen1.SelectedIndex;
 
 
                 //fen1.Item1.RemoveAt(listselect);
                 fen1.Item2.RemoveAt(listselect);
                 fen1.Hashes.RemoveAt(listselect);
 
-                lstListsInsideFEN1.Items.RemoveAt(listselect);
+                lstListsInsideFen1.Items.RemoveAt(listselect);
             }
         }
 
-        private void TxtMSBTListName_TextChanged(object sender, EventArgs e)
+        private void TxtMsbtListName_TextChanged(object sender, EventArgs e)
         {
 
         }
@@ -1154,49 +1152,49 @@ namespace MSBT_Editor
             return rootnode;
         }
 
-        private void TvwMSBFFlow_AfterSelect(object sender, TreeViewEventArgs e)
+        private void TvwMsbfFlow_AfterSelect(object sender, TreeViewEventArgs e)
         {
             FLW2 flw2 = new FLW2();
-            if (tvwMSBFFlow.Nodes.Count == 0) return;
-            if (tvwMSBFFlow.SelectedNode.Tag == default) return;
+            if (tvwMsbfFlow.Nodes.Count == 0) return;
+            if (tvwMsbfFlow.SelectedNode.Tag == default) return;
 
             //var oldindex = MsbfTreeView.SelectedNode;
-            var rootnode = Form1.Tvparenfinder(tvwMSBFFlow);
+            var rootnode = Form1.Tvparenfinder(tvwMsbfFlow);
 
             var rootnodelistbox3find = 0;
-            if (lstListsInsideFEN1.Items.Count != 0)
+            if (lstListsInsideFen1.Items.Count != 0)
             {
-                rootnodelistbox3find = lstListsInsideFEN1.Items.IndexOf(rootnode.Text);
-                lstListsInsideFEN1.SelectedIndex = rootnodelistbox3find;
+                rootnodelistbox3find = lstListsInsideFen1.Items.IndexOf(rootnode.Text);
+                lstListsInsideFen1.SelectedIndex = rootnodelistbox3find;
             }
 
 
             var roottag = (FLW2.flw2_item)rootnode.Tag;
-            var a = (FLW2.flw2_item)tvwMSBFFlow.SelectedNode.Tag;
+            var a = (FLW2.flw2_item)tvwMsbfFlow.SelectedNode.Tag;
             var find = flw2.Item.IndexOf(a);
             switch (a.TypeCheck)
             {
                 case 1:
                     //Console.WriteLine("メッセージ");
-                    if (lstListsInsideMSBT.Items.Count == 0) break;
-                    if (lstListsInsideMSBT.Items.Count > a.Unknown3) lstListsInsideMSBT.SelectedIndex = a.Unknown3;
-                    if (lstListsInsideFLW2.Items.Count == 0) break;
-                    if (lstListsInsideFLW2.Items.Count > find) lstListsInsideFLW2.SelectedIndex = find;
+                    if (lstListsInsideMsbt.Items.Count == 0) break;
+                    if (lstListsInsideMsbt.Items.Count > a.Unknown3) lstListsInsideMsbt.SelectedIndex = a.Unknown3;
+                    if (lstListsInsideFlw2.Items.Count == 0) break;
+                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
                     break;
                 case 2:
                     //Console.WriteLine("分岐");
-                    if (lstListsInsideFLW2.Items.Count == 0) break;
-                    if (lstListsInsideFLW2.Items.Count > find) lstListsInsideFLW2.SelectedIndex = find;
+                    if (lstListsInsideFlw2.Items.Count == 0) break;
+                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
                     break;
                 case 3:
                     //Console.WriteLine("イベント");
-                    if (lstListsInsideFLW2.Items.Count == 0) break;
-                    if (lstListsInsideFLW2.Items.Count > find) lstListsInsideFLW2.SelectedIndex = find;
+                    if (lstListsInsideFlw2.Items.Count == 0) break;
+                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
                     break;
                 case 4:
                     //Console.WriteLine("エントリーポイント");
-                    if (lstListsInsideFLW2.Items.Count == 0) break;
-                    if (lstListsInsideFLW2.Items.Count > find) lstListsInsideFLW2.SelectedIndex = find;
+                    if (lstListsInsideFlw2.Items.Count == 0) break;
+                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
                     break;
                 default:
 
@@ -1217,30 +1215,30 @@ namespace MSBT_Editor
 
         private void BtnInsertWorldNoTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</WorldNo>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertScoreTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</Score01>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertUserNameTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</UserName>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertTotalPlayTimeTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</TotalPlayTime>";
-            Calculation_System.TextBoxInsert(txtMSBTText, tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void textBox32_TextChanged(object sender, EventArgs e)
@@ -1281,7 +1279,7 @@ namespace MSBT_Editor
 
         }
 
-        private void BtnReloadTvwMSBFFlow_Click(object sender, EventArgs e)
+        private void BtnReloadTvwMsbfFlow_Click(object sender, EventArgs e)
         {
             var yesno = MessageBox.Show("ツリーを更新しますか？", "質問", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
             if (yesno == DialogResult.No) return;
@@ -1289,26 +1287,26 @@ namespace MSBT_Editor
             try { FEN1.TreeLoder(fen1.Item2); }
             catch (Exception ex)
             {
-                tvwMSBFFlow.Nodes.Clear();
+                tvwMsbfFlow.Nodes.Clear();
                 Console.WriteLine("errrrrrror");
             }
 
         }
 
-        private void ChkShowTvwMSBFFlow_CheckedChanged(object sender, EventArgs e)
+        private void ChkShowTvwMsbfFlow_CheckedChanged(object sender, EventArgs e)
         {
-            if (chkShowTvwMSBFFlow.Checked)
+            if (chkShowTvwMsbfFlow.Checked)
             {
-                btnReloadTvwMSBFFlow.Enabled = true;
-                tvwMSBFFlow.Enabled = true;
-                chkShowTvwMSBFFlow.Text = "ON";
+                btnReloadTvwMsbfFlow.Enabled = true;
+                tvwMsbfFlow.Enabled = true;
+                chkShowTvwMsbfFlow.Text = "ON";
             }
             else
             {
-                btnReloadTvwMSBFFlow.Enabled = false;
-                tvwMSBFFlow.Enabled = false;
-                tvwMSBFFlow.Nodes.Clear();
-                chkShowTvwMSBFFlow.Text = "OFF";
+                btnReloadTvwMsbfFlow.Enabled = false;
+                tvwMsbfFlow.Enabled = false;
+                tvwMsbfFlow.Nodes.Clear();
+                chkShowTvwMsbfFlow.Text = "OFF";
             }
         }
 
@@ -1324,39 +1322,38 @@ namespace MSBT_Editor
 
 
 
-        private void StbOpenedRARCName_Click(object sender, EventArgs e)
+        private void StbOpenedRarcName_Click(object sender, EventArgs e)
         {
 
         }
 
-        private void LblMSBFHashCalculator_Click(object sender, EventArgs e)
+        private void LblMsbfHashCalculator_Click(object sender, EventArgs e)
         {
 
         }
         //ATR1セクションテキストボックスのキープレスイベント
-        private void TxtATR1SoundID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1SoundID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtATR1SimpleCamID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1SimpleCamID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtATR1DialogID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1DialogID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtATR1WindowID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1WindowID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtATR1EventCameraID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1EventCameraID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtATR1MessageAreaID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1MessageAreaID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtATR1Unknown6_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1Unknown6_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtATR1SpecialText_KeyPress(object sender, KeyPressEventArgs e)
+        private void TxtAtr1SpecialText_KeyPress(object sender, KeyPressEventArgs e)
         {
-
             KeyPressEventSupport.CanWriteChar(e, true);
         }
 
         private void textBox30_MouseClick(object sender, MouseEventArgs e)
         {
-            this.txtSelectedMSBTListName.SelectAll();
+            this.txtSelectedMsbtListName.SelectAll();
         }
 
         private void BtnInsertCustomIconTag_Click(object sender, EventArgs e)
@@ -1369,14 +1366,14 @@ namespace MSBT_Editor
             //例:<UserIcon="000E0003 00350002003A">
             if (StrCount != 12) return;
 
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
 
             Tag = "<UserIcon=\"000E0003" + Tag + "\">";
 
 
 
 
-            Calculation_System.TextBoxInsert(txtMSBTText, Tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, Tag);
         }
 
         private void UserIconInsertTextBox_TextChanged(object sender, EventArgs e)
@@ -1398,52 +1395,52 @@ namespace MSBT_Editor
             var Tag = txtSoundEffectName.Text;
             if (Tag == string.Empty) return;
 
-            if (lstListsInsideMSBT.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1) return;
 
             Tag = "<SE=\"" + Tag + "\">";
-            Calculation_System.TextBoxInsert(txtMSBTText, Tag);
+            Calculation_System.TextBoxInsert(txtMsbtText, Tag);
         }
 
-        private void TxtReadOnlyMSBTText_TextChanged(object sender, EventArgs e)
+        private void TxtReadOnlyMsbtText_TextChanged(object sender, EventArgs e)
         {
 
         }
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
-            var ResourceARCFolder = Path.GetDirectoryName(Application.ExecutablePath) + "\\res\\" + "ARC";
-            if (Directory.Exists(ResourceARCFolder)) Directory.Delete(ResourceARCFolder, true);
+            var ResourceRarcFolder = Path.GetDirectoryName(Application.ExecutablePath) + "\\res\\" + "ARC";
+            if (Directory.Exists(ResourceRarcFolder)) Directory.Delete(ResourceRarcFolder, true);
         }
 
 
 
-        private void LlbGitHubReleasesURL_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void LlbGitHubReleasesUrl_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            this.llbGitHubReleasesURL.LinkVisited = true;
+            this.llbGitHubReleasesUrl.LinkVisited = true;
             System.Diagnostics.Process.Start("https://github.com/penguin117117/MSBT_Editor/releases");
         }
 
-        private void LlbGitHubRepositoryURL_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void LlbGitHubRepositoryUrl_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            this.llbGitHubRepositoryURL.LinkVisited = true;
+            this.llbGitHubRepositoryUrl.LinkVisited = true;
             System.Diagnostics.Process.Start("https://github.com/penguin117117/MSBT_Editor");
         }
 
-        private void LlbGitHubIssuesURL_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void LlbGitHubIssuesUrl_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            this.llbGitHubIssuesURL.LinkVisited = true;
+            this.llbGitHubIssuesUrl.LinkVisited = true;
             System.Diagnostics.Process.Start("https://github.com/penguin117117/MSBT_Editor/issues");
         }
 
-        private void LlbSMG2HackWikiURL_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void LlbSMG2HackWikiUrl_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            this.llbSMG2HackWikiURL.LinkVisited = true;
+            this.llbSMG2HackWikiUrl.LinkVisited = true;
             System.Diagnostics.Process.Start("http://mariogalaxy2hack.wiki.fc2.com/wiki/MSBT_Editor");
         }
 
-        private void LlbSMG2HackDiscordURL_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void LlbSMG2HackDiscordUrl_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            this.llbSMG2HackDiscordURL.LinkVisited = true;
+            this.llbSMG2HackDiscordUrl.LinkVisited = true;
             System.Diagnostics.Process.Start("https://discord.gg/B4EwY7h");
         }
 
@@ -1452,23 +1449,23 @@ namespace MSBT_Editor
 
         }
 
-        private void TxtFLW2FlowType_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtFlw2FlowType_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtFLW2BranchTrue_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtFlw2BranchTrue_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void button1_Click(object sender, EventArgs e)
+        private void BtnTextSort_Click(object sender, EventArgs e)
         {
-            string[] OldStrings = UnknownTag.Text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-            UnknownTag.Text = string.Empty;
+            string[] OldStrings = txtUnknownTag.Text.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            txtUnknownTag.Text = string.Empty;
             var Sorted = OldStrings.OrderBy(sort => sort).ToArray();
 
-            foreach (var tes in Sorted) UnknownTag.AppendText(tes + Environment.NewLine);
+            foreach (var tes in Sorted) txtUnknownTag.AppendText(tes + Environment.NewLine);
         }
 
-        private void ChkMSBAutoSave_CheckedChanged(object sender, EventArgs e)
+        private void ChkMsbAutoSave_CheckedChanged(object sender, EventArgs e)
         {
 
-            if (chkMSBAutoSave.Checked == false)
+            if (chkMsbAutoSave.Checked == false)
             {
                 s_useAutoSave = false;
             }
@@ -1478,19 +1475,19 @@ namespace MSBT_Editor
             }
         }
 
-        private void LstFilesInsideRARC_SelectedValueChanged(object sender, EventArgs e)
+        private void LstFilesInsideRarc_SelectedValueChanged(object sender, EventArgs e)
         {
-            Console.WriteLine(lstFilesInsideRARC.SelectedValue);
+            Console.WriteLine(lstFilesInsideRarc.SelectedValue);
         }
-        private void LstFilesInsideRARC_SelectedIndexChanged(object sender, EventArgs e/*EventHandler e*/)
+        private void LstFilesInsideRarc_SelectedIndexChanged(object sender, EventArgs e/*EventHandler e*/)
         {
 
             var SaveSelect = DialogResult;
 
             if (Dialog.ArcInsideMsbtAndMsbfPath.Count < 1) return;
-            if (lstFilesInsideRARC.Items.Count < 0) return;
+            if (lstFilesInsideRarc.Items.Count < 0) return;
 
-            var Index = lstFilesInsideRARC.SelectedIndex;
+            var Index = lstFilesInsideRarc.SelectedIndex;
             if (Properties.Settings.Default.ARCListIndexOld == -1)
             {
                 Properties.Settings.Default.ARCListIndexOld = Index;
@@ -1519,19 +1516,19 @@ namespace MSBT_Editor
             //if (s_useAutoSave == true) SaveSelect = DialogResult.Yes;
 
             //連続で選択した際にデータが壊れないようにしています。
-            lstFilesInsideRARC.Enabled = false;
+            lstFilesInsideRarc.Enabled = false;
 
-            var PathExtention = Path.GetExtension(lstFilesInsideRARC.Text).ToLower();
-            var PathFileName = lstFilesInsideRARC.Text;
+            var PathExtention = Path.GetExtension(lstFilesInsideRarc.Text).ToLower();
+            var PathFileName = lstFilesInsideRarc.Text;
             //Dialog.FileCheckの処理中にこのイベントを発生させないようにしている。
-            this.lstFilesInsideRARC.SelectedIndexChanged -= new EventHandler(this.LstFilesInsideRARC_SelectedIndexChanged);
+            this.lstFilesInsideRarc.SelectedIndexChanged -= new EventHandler(this.LstFilesInsideRarc_SelectedIndexChanged);
 
             //if (Path.GetExtension()) ;
-            var OldPath = lstFilesInsideRARC.Items[Properties.Settings.Default.ARCListIndexOld].ToString();
+            var OldPath = lstFilesInsideRarc.Items[Properties.Settings.Default.ARCListIndexOld].ToString();
 
 
-            var MsbtOldName = stbOpenedMSBTName.Text;
-            var MsbfOldName = stbOpenedMSBFName.Text;
+            var MsbtOldName = stbOpenedMsbtName.Text;
+            var MsbfOldName = stbOpenedMsbfName.Text;
 
             bool IsMsbtDef = false;
             bool IsMsbfDef = false;
@@ -1546,7 +1543,7 @@ namespace MSBT_Editor
                 if (MsbfOldName == Langage.FileReadStatusUS[1]) IsMsbfDef = true;
             }
 
-            if ((PathExtention == ".msbt") && (Dialog.Save_Path_Msbt != lstFilesInsideRARC.Text))
+            if ((PathExtention == ".msbt") && (Dialog.Save_Path_Msbt != lstFilesInsideRarc.Text))
             {
 
                 if ((s_useAutoSave == false) && (MsbtOldName != PathFileName) && IsMsbtDef == false)
@@ -1589,7 +1586,7 @@ namespace MSBT_Editor
 
 
             }
-            else if ((PathExtention == ".msbf") && (Dialog.Save_Path_Msbf != lstFilesInsideRARC.Text))
+            else if ((PathExtention == ".msbf") && (Dialog.Save_Path_Msbf != lstFilesInsideRarc.Text))
             {
                 if ((s_useAutoSave == false) && (MsbfOldName != PathFileName) && IsMsbfDef == false)
                 {
@@ -1606,8 +1603,8 @@ namespace MSBT_Editor
                 if (DialogResult.No == SaveSelect)
                 {
                     if (Properties.Settings.Default.ARCListIndexOld < 0) return;
-                    lstFilesInsideRARC.SelectedIndex = Properties.Settings.Default.ARCListIndexOld;
-                    lstFilesInsideRARC.Enabled = true;
+                    lstFilesInsideRarc.SelectedIndex = Properties.Settings.Default.ARCListIndexOld;
+                    lstFilesInsideRarc.Enabled = true;
                     return;
                 }
 
@@ -1619,54 +1616,54 @@ namespace MSBT_Editor
             }
             else
             {
-                this.lstFilesInsideRARC.SelectedIndexChanged += new EventHandler(this.LstFilesInsideRARC_SelectedIndexChanged);
-                lstFilesInsideRARC.Enabled = true;
+                this.lstFilesInsideRarc.SelectedIndexChanged += new EventHandler(this.LstFilesInsideRarc_SelectedIndexChanged);
+                lstFilesInsideRarc.Enabled = true;
                 return;
             }
 
             //MSBTの内容を一度全て消す
-            txtMSBTText.Clear();
-            txtReadOnlyMSBTText.Clear();
-            txtATR1SoundID.Clear();
-            txtATR1SimpleCamID.Clear();
-            txtATR1DialogID.Clear();
-            txtATR1WindowID.Clear();
-            txtATR1EventCameraID.Clear();
-            txtATR1MessageAreaID.Clear();
-            txtATR1Unknown6.Clear();
-            txtATR1SpecialTextOffset.Clear();
-            txtATR1SpecialText.Clear();
-            txtSelectedMSBTListName.Clear();
-            lblMSBTListSelectIndex.Text = "0x00";
+            txtMsbtText.Clear();
+            txtReadOnlyMsbtText.Clear();
+            txtAtr1SoundID.Clear();
+            txtAtr1SimpleCamID.Clear();
+            txtAtr1DialogID.Clear();
+            txtAtr1WindowID.Clear();
+            txtAtr1EventCameraID.Clear();
+            txtAtr1MessageAreaID.Clear();
+            txtAtr1Unknown6.Clear();
+            txtAtr1SpecialTextOffset.Clear();
+            txtAtr1SpecialText.Clear();
+            txtSelectedMsbtListName.Clear();
+            lblMsbtListSelectIndex.Text = "0x00";
 
             Dialog.FileCheck(Dialog.ArcInsideMsbtAndMsbfPath[Index]);
 
 
 
-            this.lstFilesInsideRARC.SelectedIndexChanged += new EventHandler(this.LstFilesInsideRARC_SelectedIndexChanged);
+            this.lstFilesInsideRarc.SelectedIndexChanged += new EventHandler(this.LstFilesInsideRarc_SelectedIndexChanged);
 
             //古いリストのセレクト番号を上書き
             Properties.Settings.Default.ARCListIndexOld = Index;
             Properties.Settings.Default.Save();
 
-            lstFilesInsideRARC.Enabled = true;
-            lstFilesInsideRARC.Focus();
+            lstFilesInsideRarc.Enabled = true;
+            lstFilesInsideRarc.Focus();
         }
 
-        private void LstFilesInsideRARC_CursorChanged(object sender, EventArgs e)
+        private void LstFilesInsideRarc_CursorChanged(object sender, EventArgs e)
         {
-            Console.WriteLine(lstFilesInsideRARC.SelectedValue);
+            Console.WriteLine(lstFilesInsideRarc.SelectedValue);
         }
 
-        private void LstFilesInsideRARC_Validating(object sender, CancelEventArgs e)
+        private void LstFilesInsideRarc_Validating(object sender, CancelEventArgs e)
         {
-            Console.WriteLine(lstFilesInsideRARC.SelectedValue);
+            Console.WriteLine(lstFilesInsideRarc.SelectedValue);
         }
 
-        private void LstFilesInsideRARC_ChangeUICues(object sender, UICuesEventArgs e)
+        private void LstFilesInsideRarc_ChangeUICues(object sender, UICuesEventArgs e)
         {
 
-            Console.WriteLine(lstFilesInsideRARC.SelectedValue);
+            Console.WriteLine(lstFilesInsideRarc.SelectedValue);
         }
     }
 }

--- a/MSBT_Editor/Formsys/objects.cs
+++ b/MSBT_Editor/Formsys/objects.cs
@@ -9,17 +9,17 @@ namespace MSBT_Editor.Formsys
 {
     public class objects
     {
-        protected static TextBox txtb1 = Form1.Form1Instance.txtMSBTText;
+        protected static TextBox txtb1 = Form1.Form1Instance.txtMsbtText;
         protected static TextBox txtb2 = Form1.Form1Instance.textBox2;
-        protected static TextBox txtb11 = Form1.Form1Instance.txtATR1SpecialText;
-        protected static TextBox txtb14 = Form1.Form1Instance.txtLBL1EntrySize;
-        protected static TextBox txtb15 = Form1.Form1Instance.txtATR1EntrySize;
-        protected static TextBox txtb24 = Form1.Form1Instance.txtFLW2Arg4;
+        protected static TextBox txtb11 = Form1.Form1Instance.txtAtr1SpecialText;
+        protected static TextBox txtb14 = Form1.Form1Instance.txtLbl1EntrySize;
+        protected static TextBox txtb15 = Form1.Form1Instance.txtAtr1EntrySize;
+        protected static TextBox txtb24 = Form1.Form1Instance.txtFlw2Arg4;
         protected static TextBox txtb27 = Form1.Form1Instance.textBox27;
 
         //button 1~9
-        protected static Button listadd = Form1.Form1Instance.btnAddMSBTList;
-        protected static Button listdelete = Form1.Form1Instance.btnDeleteMSBTList;
+        protected static Button listadd = Form1.Form1Instance.btnAddMsbtList;
+        protected static Button listdelete = Form1.Form1Instance.btnDeleteMsbtList;
         protected static Button button1 = Form1.Form1Instance.btnInsertColorTag;
         protected static Button button2 = Form1.Form1Instance.btnInsertLineControlTag;
         protected static Button button3 = Form1.Form1Instance.btnInsertFontSizeTag;
@@ -42,10 +42,10 @@ namespace MSBT_Editor.Formsys
         protected static Button button18 = Form1.Form1Instance.btnInsertSecondTag;
         protected static Button button19 = Form1.Form1Instance.btnInsertNumbersBelowDecimalPoint;
 
-        protected static Button button21 = Form1.Form1Instance.btnAddFLW2List;
-        protected static Button button22 = Form1.Form1Instance.btnDeleteFLW2List;
-        protected static Button button23 = Form1.Form1Instance.btnAddFEN1List;
-        protected static Button button24 = Form1.Form1Instance.btnDeleteFEN1List;
+        protected static Button button21 = Form1.Form1Instance.btnAddFlw2List;
+        protected static Button button22 = Form1.Form1Instance.btnDeleteFlw2List;
+        protected static Button button23 = Form1.Form1Instance.btnAddFen1List;
+        protected static Button button24 = Form1.Form1Instance.btnDeleteFen1List;
 
         protected static Button button26 = Form1.Form1Instance.btnInsertWorldNoTag;
         protected static Button button27 = Form1.Form1Instance.btnInsertScoreTag;
@@ -56,22 +56,22 @@ namespace MSBT_Editor.Formsys
         protected static Button UserIconInsertButton = Form1.Form1Instance.btnInsertCustomIconTag;
 
         //label 0～9
-        protected static Label labeltxt01 = Form1.Form1Instance.lblATR1SoundID;
-        protected static Label labeltxt02 = Form1.Form1Instance.lblATR1SimpleCamID;
-        protected static Label labeltxt03 = Form1.Form1Instance.lblATR1DialogID;
-        protected static Label labeltxt04 = Form1.Form1Instance.lblATR1WindowID;
-        protected static Label labeltxt05 = Form1.Form1Instance.lblATR1EventCameraID;
-        protected static Label labeltxt06 = Form1.Form1Instance.lblATR1MessageAreaID;
-        protected static Label labeltxt07 = Form1.Form1Instance.lblATR1Unknown6;
-        protected static Label labeltxt08 = Form1.Form1Instance.lblATR1SpecialTextOffset;
-        protected static Label labeltxt09 = Form1.Form1Instance.lblATR1SpecialText;
+        protected static Label labeltxt01 = Form1.Form1Instance.lblAtr1SoundID;
+        protected static Label labeltxt02 = Form1.Form1Instance.lblAtr1SimpleCamID;
+        protected static Label labeltxt03 = Form1.Form1Instance.lblAtr1DialogID;
+        protected static Label labeltxt04 = Form1.Form1Instance.lblAtr1WindowID;
+        protected static Label labeltxt05 = Form1.Form1Instance.lblAtr1EventCameraID;
+        protected static Label labeltxt06 = Form1.Form1Instance.lblAtr1MessageAreaID;
+        protected static Label labeltxt07 = Form1.Form1Instance.lblAtr1Unknown6;
+        protected static Label labeltxt08 = Form1.Form1Instance.lblAtr1SpecialTextOffset;
+        protected static Label labeltxt09 = Form1.Form1Instance.lblAtr1SpecialText;
 
         //label 10～19
-        protected static Label labeltxt10 = Form1.Form1Instance.lblLBL1TagIndex;
-        protected static Label labeltxt11 = Form1.Form1Instance.lblMSBTListName;
-        protected static Label labeltxt12 = Form1.Form1Instance.lblMSBTListEditDiscription;
-        protected static Label labeltxt13 = Form1.Form1Instance.lblMSBTListEditNote;
-        protected static Label labeltxt15 = Form1.Form1Instance.lblCreditSectionEntrySizegbxCreditSectionEntrySizeNote;
+        protected static Label labeltxt10 = Form1.Form1Instance.lblLbl1TagIndex;
+        protected static Label labeltxt11 = Form1.Form1Instance.lblMsbtListName;
+        protected static Label labeltxt12 = Form1.Form1Instance.lblMsbtListEditDiscription;
+        protected static Label labeltxt13 = Form1.Form1Instance.lblMsbtListEditNote;
+        protected static Label labeltxt15 = Form1.Form1Instance.lblCreditSectionEntrySize;
 
         protected static Label labeltxt17 = Form1.Form1Instance.lblRubiTagRubiCount;
         protected static Label labeltxt18 = Form1.Form1Instance.lblRubiTagKanjiCount;
@@ -82,22 +82,22 @@ namespace MSBT_Editor.Formsys
         protected static Label labeltxt20 = Form1.Form1Instance.lblCharacterIconTag;
         protected static Label labeltxt21 = Form1.Form1Instance.lblObjectIconTag;
         protected static Label labeltxt22 = Form1.Form1Instance.lblOthersIconTag;
-        protected static Label labeltxt23 = Form1.Form1Instance.lblFLW2FlowType;
-        protected static Label labeltxt24 = Form1.Form1Instance.lblFLW2Padding;
-        protected static Label labeltxt25 = Form1.Form1Instance.lblFLW2Arg1;
-        protected static Label labeltxt26 = Form1.Form1Instance.lblFLW2Arg2;
-        protected static Label labeltxt27 = Form1.Form1Instance.lblFLW2Arg3;
-        protected static Label labeltxt28 = Form1.Form1Instance.lblFLW2Arg4;
-        protected static Label labeltxt29 = Form1.Form1Instance.lblFLW2BranchTrue;
+        protected static Label labeltxt23 = Form1.Form1Instance.lblFlw2FlowType;
+        protected static Label labeltxt24 = Form1.Form1Instance.lblFlw2Padding;
+        protected static Label labeltxt25 = Form1.Form1Instance.lblFlw2Arg1;
+        protected static Label labeltxt26 = Form1.Form1Instance.lblFlw2Arg2;
+        protected static Label labeltxt27 = Form1.Form1Instance.lblFlw2Arg3;
+        protected static Label labeltxt28 = Form1.Form1Instance.lblFlw2Arg4;
+        protected static Label labeltxt29 = Form1.Form1Instance.lblFlw2BranchTrue;
 
         //label 30～39
-        protected static Label labeltxt30 = Form1.Form1Instance.lblFLW2BranchFalse;
-        protected static Label labeltxt31 = Form1.Form1Instance.lblFEN1Arg0;
-        protected static Label labeltxt32 = Form1.Form1Instance.lblFLW2StartIndex;
-        protected static Label labeltxt33 = Form1.Form1Instance.lblMSBFSettingNote;
-        protected static Label labeltxt34 = Form1.Form1Instance.lblFLW2ListEditDiscription;
-        protected static Label labeltxt35 = Form1.Form1Instance.lblFEN1ListName;
-        protected static Label labeltxt39 = Form1.Form1Instance.lblCreditLBL1Note;
+        protected static Label labeltxt30 = Form1.Form1Instance.lblFlw2BranchFalse;
+        protected static Label labeltxt31 = Form1.Form1Instance.lblFen1Arg0;
+        protected static Label labeltxt32 = Form1.Form1Instance.lblFlw2StartIndex;
+        protected static Label labeltxt33 = Form1.Form1Instance.lblMsbfSettingNote;
+        protected static Label labeltxt34 = Form1.Form1Instance.lblFlw2ListEditDiscription;
+        protected static Label labeltxt35 = Form1.Form1Instance.lblFen1ListName;
+        protected static Label labeltxt39 = Form1.Form1Instance.lblCreditLbl1Note;
 
         protected static Label Label58 = Form1.Form1Instance.lblSaveSystemDiscription;
 
@@ -107,17 +107,17 @@ namespace MSBT_Editor.Formsys
         protected static Label SETagInsertLabel2 = Form1.Form1Instance.lblSoundEffectTagDiscription2;
 
         protected static TextBox msbtdebugtxt = Form1.Form1Instance.MSBT_Debug_Text;
-        protected static TextBox txtb13 = Form1.Form1Instance.textBox13;
-        protected static ListBox MsbtListBox = Form1.Form1Instance.lstListsInsideMSBT;
-        protected static ListBox list2 = Form1.Form1Instance.lstListsInsideFLW2;
-        protected static ListBox list3 = Form1.Form1Instance.lstListsInsideFEN1;
-        protected static ListBox ARCListBox = Form1.Form1Instance.lstFilesInsideRARC;
+        protected static TextBox txtb13 = Form1.Form1Instance.txtFlw2DebugHex;
+        protected static ListBox MsbtListBox = Form1.Form1Instance.lstListsInsideMsbt;
+        protected static ListBox list2 = Form1.Form1Instance.lstListsInsideFlw2;
+        protected static ListBox list3 = Form1.Form1Instance.lstListsInsideFen1;
+        protected static ListBox ARCListBox = Form1.Form1Instance.lstFilesInsideRarc;
 
         //
-        protected static TreeView treeview1 = Form1.Form1Instance.tvwMSBFFlow;
+        protected static TreeView treeview1 = Form1.Form1Instance.tvwMsbfFlow;
 
         //
-        protected static CheckBox chk1 = Form1.Form1Instance.chkShowTvwMSBFFlow;
+        protected static CheckBox chk1 = Form1.Form1Instance.chkShowTvwMsbfFlow;
 
         //combbox
         protected static ComboBox combo1 = Form1.Form1Instance.cmbColorTag;
@@ -129,12 +129,12 @@ namespace MSBT_Editor.Formsys
         protected static ComboBox combo7 = Form1.Form1Instance.cmbOthersIconTag;
 
         //groupbox
-        protected static GroupBox Atr1GroupBox = Form1.Form1Instance.gbxMSBTSettingsATR1;
+        protected static GroupBox Atr1GroupBox = Form1.Form1Instance.gbxMsbtSettingsAtr1;
         protected static GroupBox groupbox3 = Form1.Form1Instance.gbxCreditSectionEntrySize;
         protected static GroupBox groupbox4 = Form1.Form1Instance.gbxRubiTag;
         protected static GroupBox groupbox5 = Form1.Form1Instance.gbxTimerTag;
         protected static GroupBox groupbox6 = Form1.Form1Instance.gbxSpecialTag;
-        protected static GroupBox groupbox8 = Form1.Form1Instance.gbxFLW2Branch;
+        protected static GroupBox groupbox8 = Form1.Form1Instance.gbxFlw2Branch;
 
         protected static GroupBox groupbox15 = Form1.Form1Instance.gbxCustomIconTag;
         protected static GroupBox groupbox16 = Form1.Form1Instance.gbxSoundEffectTag;
@@ -142,17 +142,17 @@ namespace MSBT_Editor.Formsys
         //tab
         protected static TabControl tbc1 = Form1.Form1Instance.tabControl1;
         protected static TabControl tbc3 = Form1.Form1Instance.tabControl3;
-        protected static TabPage tabp1 = Form1.Form1Instance.tbpMSBTSettings;
-        protected static TabPage tabp2 = Form1.Form1Instance.tabPage2;
+        protected static TabPage tabp1 = Form1.Form1Instance.tbpMsbtSetting;
+        protected static TabPage tabp2 = Form1.Form1Instance.tbpMsbtTextEdit;
         protected static TabPage tabp3 = Form1.Form1Instance.tbpListEdit;
-        protected static TabPage tabp4 = Form1.Form1Instance.tbpMSBFSetting;
+        protected static TabPage tabp4 = Form1.Form1Instance.tbpMsbfSetting;
         protected static TabPage AdvancedTagsTabPage = Form1.Form1Instance.AdvancedTagsTabPage;
 
-        protected static TabPage tabp6 = Form1.Form1Instance.tabPage6;
-        protected static TabPage tabp7 = Form1.Form1Instance.tabPage7;
-        protected static TabPage tabp8 = Form1.Form1Instance.tabPage8;
-        protected static TabPage tabp9 = Form1.Form1Instance.tabPage9;
-        protected static TabPage tabp12 = Form1.Form1Instance.tbpFilesInsideRARC;
+        protected static TabPage tabp6 = Form1.Form1Instance.tbpGeneralTag;
+        protected static TabPage tabp7 = Form1.Form1Instance.tbpValueTag;
+        protected static TabPage tabp8 = Form1.Form1Instance.tbpSpecialTag;
+        protected static TabPage tabp9 = Form1.Form1Instance.tbpIconTag;
+        protected static TabPage tabp12 = Form1.Form1Instance.tbpFilesInsideRarc;
         protected static TabPage tabp14 = Form1.Form1Instance.tbpInfomation;
 
         //menu
@@ -169,14 +169,14 @@ namespace MSBT_Editor.Formsys
 
         //stats
         protected static ToolStripStatusLabel tssl1 = Form1.Form1Instance.stbStatusLabel;
-        protected static ToolStripStatusLabel tssl2 = Form1.Form1Instance.stbOpenedMSBTName;
-        protected static ToolStripStatusLabel tssl4 = Form1.Form1Instance.stbOpenedMSBFName;
+        protected static ToolStripStatusLabel tssl2 = Form1.Form1Instance.stbOpenedMsbtName;
+        protected static ToolStripStatusLabel tssl4 = Form1.Form1Instance.stbOpenedMsbfName;
         protected static ToolStripStatusLabel tssl6 = Form1.Form1Instance.stbSavedFilePathLabel;
-        protected static ToolStripStatusLabel tssl7 = Form1.Form1Instance.stbOpenedRARCName;
+        protected static ToolStripStatusLabel tssl7 = Form1.Form1Instance.stbOpenedRarcName;
         protected static ToolStripStatusLabel SaveStatusPathString = Form1.Form1Instance.stbSavedFilePath;
 
         //
-        protected static TextBox unknowntag = Form1.Form1Instance.UnknownTag;
+        protected static TextBox unknowntag = Form1.Form1Instance.txtUnknownTag;
        
     }
 }


### PR DESCRIPTION
## 概要
Form1.csのコントロール群の名前における、MSBT, LBL1, MSBF, FLW2などのマジック文字列に
キャメルケースを適用するようリファクタリングし、可読性を向上させる

## 目的
今後行う予定の、Form1.csをMVCの責務ごとに分離するリファクタリングを円滑に進めるため

## 変更内容
- [x] #24 でリネームしたコントロール群の名前におけるマジック文字列にキャメルケースを適用
- [ ] コントローラー群のテキストにおけるマジック文字列を全て大文字に統一（一部完了）
- [ ] 名前が初期値のままのコントロールの命名（一部完了）

## ユーザーやシステムへの影響範囲
とくになし

## to-do
- [ ] コントロール名からプレフィックスを削除し、名前末尾にコントロールの種類を加える