### PR TITLE
MSBTファイル再読み込み時に例外が発生する不具合を修正

### DIFF
--- a/MSBT_Editor/FileSys/Dialog.cs
+++ b/MSBT_Editor/FileSys/Dialog.cs
@@ -230,24 +230,24 @@ namespace MSBT_Editor.FileSys
             {
                 case ".msbt":
                     Save_Path_Msbt = filePath;
-                    Langage.DefaultStatusBarLabel(tssl2, Langage.FileReadStatusJP[0], Langage.FileReadStatusUS[0]);
+                    Language.DefaultStatusBarLabel(tssl2, Language.FileReadStatusJP[0], Language.FileReadStatusUS[0]);
                     MSBT_Header msbth = new MSBT_Header();
                     msbth.Read(filePath);
                     //ARCListBox.Items.Clear();
                     //Save_Path_Arc = "None";
                     //Temp_Path_Arc = "None";
-                    //Langage.DefaultStatusBarLabel(tssl7, Langage.FileReadStatusJP[2], Langage.FileReadStatusUS[2]);
+                    //Language.DefaultStatusBarLabel(tssl7, Language.FileReadStatusJP[2], Language.FileReadStatusUS[2]);
                     tssl2.Text = Path.GetFileName(filePath);
                     break;
                 case ".msbf":
                     Save_Path_Msbf = filePath;
-                    Langage.DefaultStatusBarLabel(tssl4, Langage.FileReadStatusJP[1], Langage.FileReadStatusUS[1]);
+                    Language.DefaultStatusBarLabel(tssl4, Language.FileReadStatusJP[1], Language.FileReadStatusUS[1]);
                     MSBF_Header msbfh = new MSBF_Header();
                     msbfh.Read(MSBF_File_Path);
                     //ARCListBox.Items.Clear();
                     //Save_Path_Arc = "None";
                     //Temp_Path_Arc = "None";
-                    //Langage.DefaultStatusBarLabel(tssl7, Langage.FileReadStatusJP[2], Langage.FileReadStatusUS[2]);
+                    //Language.DefaultStatusBarLabel(tssl7, Language.FileReadStatusJP[2], Language.FileReadStatusUS[2]);
                     tssl4.Text = Path.GetFileName(MSBF_File_Path);
                     break;
                 case ".arc":
@@ -255,16 +255,16 @@ namespace MSBT_Editor.FileSys
                     Properties.Settings.Default.Save();
                     Dialog.Save_Path_Msbt = "None";
                     Dialog.Save_Path_Msbf = "None";
-                    tssl2.Text = Langage.FileReadStatusJP[0];
-                    tssl4.Text = Langage.FileReadStatusJP[1];
+                    tssl2.Text = Language.FileReadStatusJP[0];
+                    tssl4.Text = Language.FileReadStatusJP[1];
                     if (Properties.Settings.Default.言語 == "EN") 
                     {
-                        tssl2.Text = Langage.FileReadStatusUS[0];
-                        tssl4.Text = Langage.FileReadStatusUS[1];
+                        tssl2.Text = Language.FileReadStatusUS[0];
+                        tssl4.Text = Language.FileReadStatusUS[1];
                     }
-                    Langage.StatusBarLabelChenger(tssl2, Langage.FileReadStatusUS[0], Langage.FileReadStatusJP[0]);
-                    Langage.StatusBarLabelChenger(tssl4, Langage.FileReadStatusUS[1], Langage.FileReadStatusJP[1]);
-                    //if (Form1.UseDevelopMenue == false) break;
+                    Language.StatusBarLabelChenger(tssl2, Language.FileReadStatusUS[0], Language.FileReadStatusJP[0]);
+                    Language.StatusBarLabelChenger(tssl4, Language.FileReadStatusUS[1], Language.FileReadStatusJP[1]);
+                    //if (Form1.EnableDevelopMenu == false) break;
                     var IsYaz0 = MagicChecker(filePath, "Yaz0");
                     if (IsYaz0 == true)
                     {
@@ -279,7 +279,7 @@ namespace MSBT_Editor.FileSys
                     //初期化
                     ARCListBox.Items.Clear();
                     Save_Path_Arc = filePath;
-                    Langage.DefaultStatusBarLabel(tssl7, Langage.FileReadStatusJP[2], Langage.FileReadStatusUS[2]);
+                    Language.DefaultStatusBarLabel(tssl7, Language.FileReadStatusJP[2], Language.FileReadStatusUS[2]);
 
                     //パスを取得
                     var FileName = Path.GetFileName(filePath);

--- a/MSBT_Editor/Form1.Designer.cs
+++ b/MSBT_Editor/Form1.Designer.cs
@@ -47,19 +47,19 @@ namespace MSBT_Editor
             this.Msbt上書き保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Msbt保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.mSBF開くToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.Msbf開くToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Msbf上書き保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.Msbf保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.ARC開くToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ARC上書き保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ARC保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.Arc開くToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.Arc上書き保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.Arc保存ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.lstListsInsideMsbt = new System.Windows.Forms.ListBox();
             this.txtMsbtText = new System.Windows.Forms.TextBox();
             this.textBox2 = new System.Windows.Forms.TextBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tbpMsbtSetting = new System.Windows.Forms.TabPage();
-            this.gbxMsbtSettingsAtr1 = new System.Windows.Forms.GroupBox();
+            this.gbxMsbtSettingAtr1 = new System.Windows.Forms.GroupBox();
             this.lblAtr1SpecialText = new System.Windows.Forms.Label();
             this.txtAtr1SpecialText = new System.Windows.Forms.TextBox();
             this.lblAtr1Unknown6 = new System.Windows.Forms.Label();
@@ -106,7 +106,7 @@ namespace MSBT_Editor
             this.btnInsertUserNameTag = new System.Windows.Forms.Button();
             this.btnInsertScoreTag = new System.Windows.Forms.Button();
             this.btnInsertWorldNoTag = new System.Windows.Forms.Button();
-            this.btnInsertNumbersBelowDecimalPoint = new System.Windows.Forms.Button();
+            this.btnInsertNumbersBelowDecimalPointTag = new System.Windows.Forms.Button();
             this.btnInsertSecondTag = new System.Windows.Forms.Button();
             this.btnInsertMinuteTag = new System.Windows.Forms.Button();
             this.btnInsertHourTag = new System.Windows.Forms.Button();
@@ -116,16 +116,16 @@ namespace MSBT_Editor
             this.btnInsertResultScenarioNameTag = new System.Windows.Forms.Button();
             this.btnInsertResultGalaxyNameTag = new System.Windows.Forms.Button();
             this.tbpIconTag = new System.Windows.Forms.TabPage();
-            this.btnInsertOthersIconTag = new System.Windows.Forms.Button();
-            this.cmbOthersIconTag = new System.Windows.Forms.ComboBox();
-            this.lblOthersIconTag = new System.Windows.Forms.Label();
+            this.btnInsertOtherIconTag = new System.Windows.Forms.Button();
+            this.cmbOtherIconTag = new System.Windows.Forms.ComboBox();
+            this.lblOtherIconTag = new System.Windows.Forms.Label();
             this.lblObjectIconTag = new System.Windows.Forms.Label();
             this.btnInsertObjectIconTag = new System.Windows.Forms.Button();
             this.cmbObjectIconTag = new System.Windows.Forms.ComboBox();
             this.lblCharacterIconTag = new System.Windows.Forms.Label();
             this.btnInsertCharacterIconTag = new System.Windows.Forms.Button();
             this.cmbCharacterIconTag = new System.Windows.Forms.ComboBox();
-            this.AdvancedTagsTabPage = new System.Windows.Forms.TabPage();
+            this.AdvancedTagTabPage = new System.Windows.Forms.TabPage();
             this.gbxSoundEffectTag = new System.Windows.Forms.GroupBox();
             this.lblSoundEffectTagDiscription1 = new System.Windows.Forms.Label();
             this.btnInsertSoundEffectTag = new System.Windows.Forms.Button();
@@ -220,7 +220,7 @@ namespace MSBT_Editor
             this.lblCreditXenon = new System.Windows.Forms.Label();
             this.lblCreditDossun = new System.Windows.Forms.Label();
             this.lblCreditPorto = new System.Windows.Forms.Label();
-            this.lblCreditHiiraghi = new System.Windows.Forms.Label();
+            this.lblCreditHiiragi = new System.Windows.Forms.Label();
             this.lblCreditEigen = new System.Windows.Forms.Label();
             this.gbxCreditSectionEntrySize = new System.Windows.Forms.GroupBox();
             this.txtAtr1EntrySize = new System.Windows.Forms.TextBox();
@@ -262,7 +262,7 @@ namespace MSBT_Editor
             this.menuStrip1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tbpMsbtSetting.SuspendLayout();
-            this.gbxMsbtSettingsAtr1.SuspendLayout();
+            this.gbxMsbtSettingAtr1.SuspendLayout();
             this.tbpMsbtTextEdit.SuspendLayout();
             this.tabControl2.SuspendLayout();
             this.tbpGeneralTag.SuspendLayout();
@@ -272,7 +272,7 @@ namespace MSBT_Editor
             this.tbpSpecialTag.SuspendLayout();
             this.gbxSpecialTag.SuspendLayout();
             this.tbpIconTag.SuspendLayout();
-            this.AdvancedTagsTabPage.SuspendLayout();
+            this.AdvancedTagTabPage.SuspendLayout();
             this.gbxSoundEffectTag.SuspendLayout();
             this.gbxCustomIconTag.SuspendLayout();
             this.tbpListEdit.SuspendLayout();
@@ -351,9 +351,8 @@ namespace MSBT_Editor
             // stbOpenedRarcName
             // 
             this.stbOpenedRarcName.Name = "stbOpenedRarcName";
-            this.stbOpenedRarcName.Size = new System.Drawing.Size(104, 17);
-            this.stbOpenedRarcName.Text = "<RARCファイルなし>";
-            this.stbOpenedRarcName.Click += new System.EventHandler(this.StbOpenedRarcName_Click);
+            this.stbOpenedRarcName.Size = new System.Drawing.Size(97, 17);
+            this.stbOpenedRarcName.Text = "<ARCファイルなし>";
             // 
             // toolStripStatusLabel8
             // 
@@ -391,13 +390,13 @@ namespace MSBT_Editor
             this.Msbt上書き保存ToolStripMenuItem,
             this.Msbt保存ToolStripMenuItem,
             this.toolStripSeparator1,
-            this.mSBF開くToolStripMenuItem,
+            this.Msbf開くToolStripMenuItem,
             this.Msbf上書き保存ToolStripMenuItem,
             this.Msbf保存ToolStripMenuItem,
             this.toolStripSeparator2,
-            this.ARC開くToolStripMenuItem,
-            this.ARC上書き保存ToolStripMenuItem,
-            this.ARC保存ToolStripMenuItem});
+            this.Arc開くToolStripMenuItem,
+            this.Arc上書き保存ToolStripMenuItem,
+            this.Arc保存ToolStripMenuItem});
             this.ファイルToolStripMenuItem.Name = "ファイルToolStripMenuItem";
             this.ファイルToolStripMenuItem.Size = new System.Drawing.Size(53, 20);
             this.ファイルToolStripMenuItem.Text = "ファイル";
@@ -437,13 +436,13 @@ namespace MSBT_Editor
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(197, 6);
             // 
-            // mSBF開くToolStripMenuItem
+            // Msbf開くToolStripMenuItem
             // 
-            this.mSBF開くToolStripMenuItem.Name = "mSBF開くToolStripMenuItem";
-            this.mSBF開くToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.mSBF開くToolStripMenuItem.Text = "MSBF開く";
-            this.mSBF開くToolStripMenuItem.Visible = false;
-            this.mSBF開くToolStripMenuItem.Click += new System.EventHandler(this.MSBF開くToolStripMenuItem_Click);
+            this.Msbf開くToolStripMenuItem.Name = "Msbf開くToolStripMenuItem";
+            this.Msbf開くToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.Msbf開くToolStripMenuItem.Text = "MSBF開く";
+            this.Msbf開くToolStripMenuItem.Visible = false;
+            this.Msbf開くToolStripMenuItem.Click += new System.EventHandler(this.Msbf開くToolStripMenuItem_Click);
             // 
             // Msbf上書き保存ToolStripMenuItem
             // 
@@ -469,28 +468,28 @@ namespace MSBT_Editor
             // 
             // ARC開くToolStripMenuItem
             // 
-            this.ARC開くToolStripMenuItem.Name = "ARC開くToolStripMenuItem";
-            this.ARC開くToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.ARC開くToolStripMenuItem.Text = "ARC開く";
-            this.ARC開くToolStripMenuItem.Visible = false;
-            this.ARC開くToolStripMenuItem.Click += new System.EventHandler(this.ARC開くToolStripMenuItem_Click);
+            this.Arc開くToolStripMenuItem.Name = "ARC開くToolStripMenuItem";
+            this.Arc開くToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.Arc開くToolStripMenuItem.Text = "ARC開く";
+            this.Arc開くToolStripMenuItem.Visible = false;
+            this.Arc開くToolStripMenuItem.Click += new System.EventHandler(this.Arc開くToolStripMenuItem_Click);
             // 
             // ARC上書き保存ToolStripMenuItem
             // 
-            this.ARC上書き保存ToolStripMenuItem.Name = "ARC上書き保存ToolStripMenuItem";
-            this.ARC上書き保存ToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.ARC上書き保存ToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.ARC上書き保存ToolStripMenuItem.Text = "ARC上書き保存";
-            this.ARC上書き保存ToolStripMenuItem.Click += new System.EventHandler(this.ARC上書き保存ToolStripMenuItem_Click);
+            this.Arc上書き保存ToolStripMenuItem.Name = "ARC上書き保存ToolStripMenuItem";
+            this.Arc上書き保存ToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.Arc上書き保存ToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.Arc上書き保存ToolStripMenuItem.Text = "ARC上書き保存";
+            this.Arc上書き保存ToolStripMenuItem.Click += new System.EventHandler(this.Arc上書き保存ToolStripMenuItem_Click);
             // 
             // ARC保存ToolStripMenuItem
             // 
-            this.ARC保存ToolStripMenuItem.Name = "ARC保存ToolStripMenuItem";
-            this.ARC保存ToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            this.Arc保存ToolStripMenuItem.Name = "ARC保存ToolStripMenuItem";
+            this.Arc保存ToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.S)));
-            this.ARC保存ToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.ARC保存ToolStripMenuItem.Text = "ARC保存";
-            this.ARC保存ToolStripMenuItem.Click += new System.EventHandler(this.ARC保存ToolStripMenuItem_Click);
+            this.Arc保存ToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.Arc保存ToolStripMenuItem.Text = "ARC保存";
+            this.Arc保存ToolStripMenuItem.Click += new System.EventHandler(this.Arc保存ToolStripMenuItem_Click);
             // 
             // lstListsInsideMsbt
             // 
@@ -541,7 +540,7 @@ namespace MSBT_Editor
             // 
             // tbpMsbtSetting
             // 
-            this.tbpMsbtSetting.Controls.Add(this.gbxMsbtSettingsAtr1);
+            this.tbpMsbtSetting.Controls.Add(this.gbxMsbtSettingAtr1);
             this.tbpMsbtSetting.Location = new System.Drawing.Point(4, 22);
             this.tbpMsbtSetting.Name = "tbpMsbtSetting";
             this.tbpMsbtSetting.Padding = new System.Windows.Forms.Padding(3);
@@ -550,30 +549,30 @@ namespace MSBT_Editor
             this.tbpMsbtSetting.Text = "MSBTテキストの詳細設定";
             this.tbpMsbtSetting.UseVisualStyleBackColor = true;
             // 
-            // gbxMsbtSettingsAtr1
+            // gbxMsbtSettingAtr1
             // 
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1SpecialText);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1SpecialText);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1Unknown6);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1MessageAreaID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1EventCameraID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1WindowID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1DialogID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1SimpleCamID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.lblAtr1SoundID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1Unknown6);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1MessageAreaID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1EventCameraID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1WindowID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1DialogID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1SimpleCamID);
-            this.gbxMsbtSettingsAtr1.Controls.Add(this.txtAtr1SoundID);
-            this.gbxMsbtSettingsAtr1.Location = new System.Drawing.Point(6, 6);
-            this.gbxMsbtSettingsAtr1.Name = "gbxMsbtSettingsAtr1";
-            this.gbxMsbtSettingsAtr1.Size = new System.Drawing.Size(548, 290);
-            this.gbxMsbtSettingsAtr1.TabIndex = 4;
-            this.gbxMsbtSettingsAtr1.TabStop = false;
-            this.gbxMsbtSettingsAtr1.Text = "選択されたMSBTメッセージの詳細設定";
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1SpecialText);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1SpecialText);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1Unknown6);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1MessageAreaID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1EventCameraID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1WindowID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1DialogID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1SimpleCamID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1SoundID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1Unknown6);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1MessageAreaID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1EventCameraID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1WindowID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1DialogID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1SimpleCamID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1SoundID);
+            this.gbxMsbtSettingAtr1.Location = new System.Drawing.Point(6, 6);
+            this.gbxMsbtSettingAtr1.Name = "gbxMsbtSettingAtr1";
+            this.gbxMsbtSettingAtr1.Size = new System.Drawing.Size(548, 290);
+            this.gbxMsbtSettingAtr1.TabIndex = 4;
+            this.gbxMsbtSettingAtr1.TabStop = false;
+            this.gbxMsbtSettingAtr1.Text = "選択されたMSBTメッセージの詳細設定";
             // 
             // lblAtr1SpecialText
             // 
@@ -599,9 +598,9 @@ namespace MSBT_Editor
             this.lblAtr1Unknown6.AutoSize = true;
             this.lblAtr1Unknown6.Location = new System.Drawing.Point(6, 175);
             this.lblAtr1Unknown6.Name = "lblAtr1Unknown6";
-            this.lblAtr1Unknown6.Size = new System.Drawing.Size(61, 12);
+            this.lblAtr1Unknown6.Size = new System.Drawing.Size(35, 12);
             this.lblAtr1Unknown6.TabIndex = 14;
-            this.lblAtr1Unknown6.Text = "分からない6";
+            this.lblAtr1Unknown6.Text = "不明6";
             // 
             // lblAtr1MessageAreaID
             // 
@@ -723,7 +722,7 @@ namespace MSBT_Editor
             this.txtAtr1SoundID.Name = "txtAtr1SoundID";
             this.txtAtr1SoundID.Size = new System.Drawing.Size(100, 19);
             this.txtAtr1SoundID.TabIndex = 0;
-            this.txtAtr1SoundID.TextChanged += new System.EventHandler(this.TxtATR1SoundID_TextChanged);
+            this.txtAtr1SoundID.TextChanged += new System.EventHandler(this.TxtAtr1SoundID_TextChanged);
             this.txtAtr1SoundID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1SoundID_KeyPress);
             // 
             // tbpMsbtTextEdit
@@ -744,7 +743,7 @@ namespace MSBT_Editor
             this.tabControl2.Controls.Add(this.tbpValueTag);
             this.tabControl2.Controls.Add(this.tbpSpecialTag);
             this.tabControl2.Controls.Add(this.tbpIconTag);
-            this.tabControl2.Controls.Add(this.AdvancedTagsTabPage);
+            this.tabControl2.Controls.Add(this.AdvancedTagTabPage);
             this.tabControl2.Location = new System.Drawing.Point(6, 268);
             this.tabControl2.Name = "tabControl2";
             this.tabControl2.SelectedIndex = 0;
@@ -950,7 +949,7 @@ namespace MSBT_Editor
             this.lblRubiTagDiscription.Name = "lblRubiTagDiscription";
             this.lblRubiTagDiscription.Size = new System.Drawing.Size(285, 24);
             this.lblRubiTagDiscription.TabIndex = 5;
-            this.lblRubiTagDiscription.Text = "例：<Rubi=\"9\" Target=\"5\">しんぎんがていこく新銀河帝国\r\n漢字の数は5文字まで対応ふりがなの上限は不明";
+            this.lblRubiTagDiscription.Text = "例：<Rubi=\"9\" Target=\"5\">しんぎんがていこく新銀河帝国\r\n漢字の数は5文字まで対応（ふりがなの上限は不明）";
             // 
             // btnInsertRubiTag
             // 
@@ -1013,7 +1012,7 @@ namespace MSBT_Editor
             this.gbxSpecialTag.Controls.Add(this.btnInsertUserNameTag);
             this.gbxSpecialTag.Controls.Add(this.btnInsertScoreTag);
             this.gbxSpecialTag.Controls.Add(this.btnInsertWorldNoTag);
-            this.gbxSpecialTag.Controls.Add(this.btnInsertNumbersBelowDecimalPoint);
+            this.gbxSpecialTag.Controls.Add(this.btnInsertNumbersBelowDecimalPointTag);
             this.gbxSpecialTag.Controls.Add(this.btnInsertSecondTag);
             this.gbxSpecialTag.Controls.Add(this.btnInsertMinuteTag);
             this.gbxSpecialTag.Controls.Add(this.btnInsertHourTag);
@@ -1071,13 +1070,13 @@ namespace MSBT_Editor
             // 
             // btnInsertNumbersBelowDecimalPoint
             // 
-            this.btnInsertNumbersBelowDecimalPoint.Location = new System.Drawing.Point(355, 100);
-            this.btnInsertNumbersBelowDecimalPoint.Name = "btnInsertNumbersBelowDecimalPoint";
-            this.btnInsertNumbersBelowDecimalPoint.Size = new System.Drawing.Size(167, 23);
-            this.btnInsertNumbersBelowDecimalPoint.TabIndex = 9;
-            this.btnInsertNumbersBelowDecimalPoint.Text = "小数点以下";
-            this.btnInsertNumbersBelowDecimalPoint.UseVisualStyleBackColor = true;
-            this.btnInsertNumbersBelowDecimalPoint.Click += new System.EventHandler(this.BtnInsertNumbersBelowDecimalPoint_Click);
+            this.btnInsertNumbersBelowDecimalPointTag.Location = new System.Drawing.Point(355, 100);
+            this.btnInsertNumbersBelowDecimalPointTag.Name = "btnInsertNumbersBelowDecimalPoint";
+            this.btnInsertNumbersBelowDecimalPointTag.Size = new System.Drawing.Size(167, 23);
+            this.btnInsertNumbersBelowDecimalPointTag.TabIndex = 9;
+            this.btnInsertNumbersBelowDecimalPointTag.Text = "小数点以下";
+            this.btnInsertNumbersBelowDecimalPointTag.UseVisualStyleBackColor = true;
+            this.btnInsertNumbersBelowDecimalPointTag.Click += new System.EventHandler(this.BtnInsertNumbersBelowDecimalPointTag_Click);
             // 
             // btnInsertSecondTag
             // 
@@ -1161,9 +1160,9 @@ namespace MSBT_Editor
             // 
             // tbpIconTag
             // 
-            this.tbpIconTag.Controls.Add(this.btnInsertOthersIconTag);
-            this.tbpIconTag.Controls.Add(this.cmbOthersIconTag);
-            this.tbpIconTag.Controls.Add(this.lblOthersIconTag);
+            this.tbpIconTag.Controls.Add(this.btnInsertOtherIconTag);
+            this.tbpIconTag.Controls.Add(this.cmbOtherIconTag);
+            this.tbpIconTag.Controls.Add(this.lblOtherIconTag);
             this.tbpIconTag.Controls.Add(this.lblObjectIconTag);
             this.tbpIconTag.Controls.Add(this.btnInsertObjectIconTag);
             this.tbpIconTag.Controls.Add(this.cmbObjectIconTag);
@@ -1180,31 +1179,31 @@ namespace MSBT_Editor
             // 
             // btnInsertOthersIconTag
             // 
-            this.btnInsertOthersIconTag.Location = new System.Drawing.Point(135, 100);
-            this.btnInsertOthersIconTag.Name = "btnInsertOthersIconTag";
-            this.btnInsertOthersIconTag.Size = new System.Drawing.Size(149, 23);
-            this.btnInsertOthersIconTag.TabIndex = 8;
-            this.btnInsertOthersIconTag.Text = "操作,その他タグ挿入";
-            this.btnInsertOthersIconTag.UseVisualStyleBackColor = true;
-            this.btnInsertOthersIconTag.Click += new System.EventHandler(this.BtnInsertOthersIconTag_Click);
+            this.btnInsertOtherIconTag.Location = new System.Drawing.Point(135, 100);
+            this.btnInsertOtherIconTag.Name = "btnInsertOthersIconTag";
+            this.btnInsertOtherIconTag.Size = new System.Drawing.Size(149, 23);
+            this.btnInsertOtherIconTag.TabIndex = 8;
+            this.btnInsertOtherIconTag.Text = "操作,その他タグ挿入";
+            this.btnInsertOtherIconTag.UseVisualStyleBackColor = true;
+            this.btnInsertOtherIconTag.Click += new System.EventHandler(this.BtnInsertOtherIconTag_Click);
             // 
             // cmbOthersIconTag
             // 
-            this.cmbOthersIconTag.FormattingEnabled = true;
-            this.cmbOthersIconTag.Location = new System.Drawing.Point(8, 102);
-            this.cmbOthersIconTag.Name = "cmbOthersIconTag";
-            this.cmbOthersIconTag.Size = new System.Drawing.Size(121, 20);
-            this.cmbOthersIconTag.TabIndex = 7;
-            this.cmbOthersIconTag.Text = "ポインター";
+            this.cmbOtherIconTag.FormattingEnabled = true;
+            this.cmbOtherIconTag.Location = new System.Drawing.Point(8, 102);
+            this.cmbOtherIconTag.Name = "cmbOthersIconTag";
+            this.cmbOtherIconTag.Size = new System.Drawing.Size(121, 20);
+            this.cmbOtherIconTag.TabIndex = 7;
+            this.cmbOtherIconTag.Text = "ポインター";
             // 
             // lblOthersIconTag
             // 
-            this.lblOthersIconTag.AutoSize = true;
-            this.lblOthersIconTag.Location = new System.Drawing.Point(6, 87);
-            this.lblOthersIconTag.Name = "lblOthersIconTag";
-            this.lblOthersIconTag.Size = new System.Drawing.Size(68, 12);
-            this.lblOthersIconTag.TabIndex = 6;
-            this.lblOthersIconTag.Text = "操作、その他";
+            this.lblOtherIconTag.AutoSize = true;
+            this.lblOtherIconTag.Location = new System.Drawing.Point(6, 87);
+            this.lblOtherIconTag.Name = "lblOthersIconTag";
+            this.lblOtherIconTag.Size = new System.Drawing.Size(68, 12);
+            this.lblOtherIconTag.TabIndex = 6;
+            this.lblOtherIconTag.Text = "操作、その他";
             // 
             // lblObjectIconTag
             // 
@@ -1262,17 +1261,17 @@ namespace MSBT_Editor
             this.cmbCharacterIconTag.TabIndex = 0;
             this.cmbCharacterIconTag.Text = "ピーチ";
             // 
-            // AdvancedTagsTabPage
+            // AdvancedTagTabPage
             // 
-            this.AdvancedTagsTabPage.Controls.Add(this.gbxSoundEffectTag);
-            this.AdvancedTagsTabPage.Controls.Add(this.gbxCustomIconTag);
-            this.AdvancedTagsTabPage.Location = new System.Drawing.Point(4, 22);
-            this.AdvancedTagsTabPage.Name = "AdvancedTagsTabPage";
-            this.AdvancedTagsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.AdvancedTagsTabPage.Size = new System.Drawing.Size(540, 141);
-            this.AdvancedTagsTabPage.TabIndex = 4;
-            this.AdvancedTagsTabPage.Text = "上級者向けタグ";
-            this.AdvancedTagsTabPage.UseVisualStyleBackColor = true;
+            this.AdvancedTagTabPage.Controls.Add(this.gbxSoundEffectTag);
+            this.AdvancedTagTabPage.Controls.Add(this.gbxCustomIconTag);
+            this.AdvancedTagTabPage.Location = new System.Drawing.Point(4, 22);
+            this.AdvancedTagTabPage.Name = "AdvancedTagTabPage";
+            this.AdvancedTagTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.AdvancedTagTabPage.Size = new System.Drawing.Size(540, 141);
+            this.AdvancedTagTabPage.TabIndex = 4;
+            this.AdvancedTagTabPage.Text = "上級者向けタグ";
+            this.AdvancedTagTabPage.UseVisualStyleBackColor = true;
             // 
             // gbxSoundEffectTag
             // 
@@ -1371,7 +1370,6 @@ namespace MSBT_Editor
             this.txtCustomIconHex.Size = new System.Drawing.Size(149, 19);
             this.txtCustomIconHex.TabIndex = 9;
             this.txtCustomIconHex.Text = "000000000000";
-            this.txtCustomIconHex.TextChanged += new System.EventHandler(this.UserIconInsertTextBox_TextChanged);
             this.txtCustomIconHex.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.UserIconInsertTextBox_KeyPress);
             // 
             // tbpListEdit
@@ -1426,7 +1424,6 @@ namespace MSBT_Editor
             this.txtFen1ListName.Name = "txtFen1ListName";
             this.txtFen1ListName.Size = new System.Drawing.Size(204, 19);
             this.txtFen1ListName.TabIndex = 1;
-            this.txtFen1ListName.TextChanged += new System.EventHandler(this.TxtFen1ListName_TextChanged);
             // 
             // lblFen1ListName
             // 
@@ -1519,8 +1516,7 @@ namespace MSBT_Editor
             this.txtSelectedMsbtListName.ReadOnly = true;
             this.txtSelectedMsbtListName.Size = new System.Drawing.Size(204, 19);
             this.txtSelectedMsbtListName.TabIndex = 1;
-            this.txtSelectedMsbtListName.MouseClick += new System.Windows.Forms.MouseEventHandler(this.textBox30_MouseClick);
-            this.txtSelectedMsbtListName.TextChanged += new System.EventHandler(this.textBox30_TextChanged);
+            this.txtSelectedMsbtListName.MouseClick += new System.Windows.Forms.MouseEventHandler(this.TxtSelectedMsbtListName_MouseClick);
             // 
             // lblMsbtListEditNote
             // 
@@ -1528,9 +1524,9 @@ namespace MSBT_Editor
             this.lblMsbtListEditNote.ForeColor = System.Drawing.Color.Red;
             this.lblMsbtListEditNote.Location = new System.Drawing.Point(6, 27);
             this.lblMsbtListEditNote.Name = "lblMsbtListEditNote";
-            this.lblMsbtListEditNote.Size = new System.Drawing.Size(176, 12);
+            this.lblMsbtListEditNote.Size = new System.Drawing.Size(198, 12);
             this.lblMsbtListEditNote.TabIndex = 5;
-            this.lblMsbtListEditNote.Text = "※ゲームの命名規則を守ってください";
+            this.lblMsbtListEditNote.Text = "※ゲーム内での命名規則を守ってください";
             // 
             // btnDeleteMsbtList
             // 
@@ -1548,7 +1544,6 @@ namespace MSBT_Editor
             this.txtMsbtListName.Name = "txtMsbtListName";
             this.txtMsbtListName.Size = new System.Drawing.Size(204, 19);
             this.txtMsbtListName.TabIndex = 0;
-            this.txtMsbtListName.TextChanged += new System.EventHandler(this.TxtMsbtListName_TextChanged);
             // 
             // btnAddMsbtList
             // 
@@ -1608,7 +1603,6 @@ namespace MSBT_Editor
             this.txtReadOnlyMsbtText.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.txtReadOnlyMsbtText.Size = new System.Drawing.Size(548, 58);
             this.txtReadOnlyMsbtText.TabIndex = 17;
-            this.txtReadOnlyMsbtText.TextChanged += new System.EventHandler(this.TxtReadOnlyMsbtText_TextChanged);
             // 
             // lblMsbfFlow
             // 
@@ -1632,9 +1626,9 @@ namespace MSBT_Editor
             this.lblMsbfSettingNote.AutoSize = true;
             this.lblMsbfSettingNote.Location = new System.Drawing.Point(6, 335);
             this.lblMsbfSettingNote.Name = "lblMsbfSettingNote";
-            this.lblMsbfSettingNote.Size = new System.Drawing.Size(210, 24);
+            this.lblMsbfSettingNote.Size = new System.Drawing.Size(216, 24);
             this.lblMsbfSettingNote.TabIndex = 14;
-            this.lblMsbfSettingNote.Text = "※まだすべての機能が解明できていないので\r\n　不具合が発生する可能性があります";
+            this.lblMsbfSettingNote.Text = "※まだすべての機能を解明できていないため、\r\n　不具合が発生する可能性があります";
             // 
             // gbxFen1
             // 
@@ -1754,18 +1748,18 @@ namespace MSBT_Editor
             this.lblFlw2BranchFalse.AutoSize = true;
             this.lblFlw2BranchFalse.Location = new System.Drawing.Point(6, 44);
             this.lblFlw2BranchFalse.Name = "lblFlw2BranchFalse";
-            this.lblFlw2BranchFalse.Size = new System.Drawing.Size(59, 12);
+            this.lblFlw2BranchFalse.Size = new System.Drawing.Size(83, 12);
             this.lblFlw2BranchFalse.TabIndex = 1;
-            this.lblFlw2BranchFalse.Text = "ジャンプ先2";
+            this.lblFlw2BranchFalse.Text = "ジャンプ先2（偽）";
             // 
             // lblFlw2BranchTrue
             // 
             this.lblFlw2BranchTrue.AutoSize = true;
             this.lblFlw2BranchTrue.Location = new System.Drawing.Point(6, 19);
             this.lblFlw2BranchTrue.Name = "lblFlw2BranchTrue";
-            this.lblFlw2BranchTrue.Size = new System.Drawing.Size(59, 12);
+            this.lblFlw2BranchTrue.Size = new System.Drawing.Size(83, 12);
             this.lblFlw2BranchTrue.TabIndex = 0;
-            this.lblFlw2BranchTrue.Text = "ジャンプ先1";
+            this.lblFlw2BranchTrue.Text = "ジャンプ先1（真）";
             // 
             // lblFlw2Arg4
             // 
@@ -1908,7 +1902,6 @@ namespace MSBT_Editor
             this.lblMsbfHashCalculator.Size = new System.Drawing.Size(107, 12);
             this.lblMsbfHashCalculator.TabIndex = 16;
             this.lblMsbfHashCalculator.Text = "MSBFハッシュ計算機";
-            this.lblMsbfHashCalculator.Click += new System.EventHandler(this.LblMsbfHashCalculator_Click);
             // 
             // textBox34
             // 
@@ -1928,7 +1921,7 @@ namespace MSBT_Editor
             this.button30.Text = "button30";
             this.button30.UseVisualStyleBackColor = true;
             this.button30.Visible = false;
-            this.button30.Click += new System.EventHandler(this.button30_Click);
+            this.button30.Click += new System.EventHandler(this.Button30_Click);
             // 
             // textBox33
             // 
@@ -1936,7 +1929,6 @@ namespace MSBT_Editor
             this.textBox33.Name = "textBox33";
             this.textBox33.Size = new System.Drawing.Size(133, 19);
             this.textBox33.TabIndex = 11;
-            this.textBox33.TextChanged += new System.EventHandler(this.textBox33_TextChanged);
             // 
             // textBox32
             // 
@@ -1944,7 +1936,7 @@ namespace MSBT_Editor
             this.textBox32.Name = "textBox32";
             this.textBox32.Size = new System.Drawing.Size(133, 19);
             this.textBox32.TabIndex = 10;
-            this.textBox32.TextChanged += new System.EventHandler(this.textBox32_TextChanged);
+            this.textBox32.TextChanged += new System.EventHandler(this.TextBox32_TextChanged);
             // 
             // btnCalculateHash
             // 
@@ -1962,7 +1954,6 @@ namespace MSBT_Editor
             this.txtListNameToCalculateHash.Name = "txtListNameToCalculateHash";
             this.txtListNameToCalculateHash.Size = new System.Drawing.Size(262, 19);
             this.txtListNameToCalculateHash.TabIndex = 8;
-            this.txtListNameToCalculateHash.TextChanged += new System.EventHandler(this.TxtListNameToCalculateHash_TextChanged);
             // 
             // richTextBox1
             // 
@@ -2184,7 +2175,7 @@ namespace MSBT_Editor
             this.gbxCreditDebugger.Controls.Add(this.lblDebuggerAcknowledgment);
             this.gbxCreditDebugger.Controls.Add(this.gbxCreditDebuggerVIP);
             this.gbxCreditDebugger.Controls.Add(this.lblCreditPorto);
-            this.gbxCreditDebugger.Controls.Add(this.lblCreditHiiraghi);
+            this.gbxCreditDebugger.Controls.Add(this.lblCreditHiiragi);
             this.gbxCreditDebugger.Controls.Add(this.lblCreditEigen);
             this.gbxCreditDebugger.Location = new System.Drawing.Point(6, 112);
             this.gbxCreditDebugger.Name = "gbxCreditDebugger";
@@ -2240,14 +2231,14 @@ namespace MSBT_Editor
             this.lblCreditPorto.TabIndex = 5;
             this.lblCreditPorto.Text = "ChurenPorto";
             // 
-            // lblCreditHiiraghi
+            // lblCreditHiiragi
             // 
-            this.lblCreditHiiraghi.AutoSize = true;
-            this.lblCreditHiiraghi.Location = new System.Drawing.Point(78, 59);
-            this.lblCreditHiiraghi.Name = "lblCreditHiiraghi";
-            this.lblCreditHiiraghi.Size = new System.Drawing.Size(47, 12);
-            this.lblCreditHiiraghi.TabIndex = 3;
-            this.lblCreditHiiraghi.Text = "柊：貴星";
+            this.lblCreditHiiragi.AutoSize = true;
+            this.lblCreditHiiragi.Location = new System.Drawing.Point(78, 59);
+            this.lblCreditHiiragi.Name = "lblCreditHiiragi";
+            this.lblCreditHiiragi.Size = new System.Drawing.Size(47, 12);
+            this.lblCreditHiiragi.TabIndex = 3;
+            this.lblCreditHiiragi.Text = "柊：貴星";
             // 
             // lblCreditEigen
             // 
@@ -2595,11 +2586,11 @@ namespace MSBT_Editor
             // chkMsbAutoSave
             // 
             this.chkMsbAutoSave.AutoSize = true;
-            this.chkMsbAutoSave.Location = new System.Drawing.Point(223, 268);
+            this.chkMsbAutoSave.Location = new System.Drawing.Point(214, 268);
             this.chkMsbAutoSave.Name = "chkMsbAutoSave";
-            this.chkMsbAutoSave.Size = new System.Drawing.Size(201, 16);
+            this.chkMsbAutoSave.Size = new System.Drawing.Size(215, 16);
             this.chkMsbAutoSave.TabIndex = 2;
-            this.chkMsbAutoSave.Text = "(Msbt Msbf) オートセーブ/AutoSave";
+            this.chkMsbAutoSave.Text = "(MSBT, MSBF) オートセーブ/AutoSave";
             this.chkMsbAutoSave.UseVisualStyleBackColor = true;
             this.chkMsbAutoSave.CheckedChanged += new System.EventHandler(this.ChkMsbAutoSave_CheckedChanged);
             // 
@@ -2608,10 +2599,10 @@ namespace MSBT_Editor
             this.lblSaveSystemDiscription.AutoSize = true;
             this.lblSaveSystemDiscription.Location = new System.Drawing.Point(6, 287);
             this.lblSaveSystemDiscription.Name = "lblSaveSystemDiscription";
-            this.lblSaveSystemDiscription.Size = new System.Drawing.Size(297, 60);
+            this.lblSaveSystemDiscription.Size = new System.Drawing.Size(235, 72);
             this.lblSaveSystemDiscription.TabIndex = 1;
-            this.lblSaveSystemDiscription.Text = "ARCファイルから開いた\r\nMsbtやMsbfの内容を変更した際は上書き保存をしてください。\r\n上書き保存してからリストを選択し直さないと、\r\n変更が保存されませ" +
-    "ん。\r\n全ての変更が終わったらARCを保存してください。";
+            this.lblSaveSystemDiscription.Text = "ARCファイルから開いたMSBTやMSBFの\r\n内容を変更した際は、上書き保存をしてください。\r\n上書き保存してからリストを選択し直さないと、\r\n変更が保存されま" +
+    "せん。\r\n全ての変更が終わったらARCを保存してください。\r\n※MSBT, MSBF以外は表示されません";
             // 
             // lstFilesInsideRarc
             // 
@@ -2666,15 +2657,14 @@ namespace MSBT_Editor
             this.Load += new System.EventHandler(this.Form1_Load);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.Form1_DragDrop);
             this.DragEnter += new System.Windows.Forms.DragEventHandler(this.Form1_DragEnter);
-            this.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.Form1_KeyPress);
             this.stbStatusBar.ResumeLayout(false);
             this.stbStatusBar.PerformLayout();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             this.tabControl1.ResumeLayout(false);
             this.tbpMsbtSetting.ResumeLayout(false);
-            this.gbxMsbtSettingsAtr1.ResumeLayout(false);
-            this.gbxMsbtSettingsAtr1.PerformLayout();
+            this.gbxMsbtSettingAtr1.ResumeLayout(false);
+            this.gbxMsbtSettingAtr1.PerformLayout();
             this.tbpMsbtTextEdit.ResumeLayout(false);
             this.tbpMsbtTextEdit.PerformLayout();
             this.tabControl2.ResumeLayout(false);
@@ -2688,7 +2678,7 @@ namespace MSBT_Editor
             this.gbxSpecialTag.ResumeLayout(false);
             this.tbpIconTag.ResumeLayout(false);
             this.tbpIconTag.PerformLayout();
-            this.AdvancedTagsTabPage.ResumeLayout(false);
+            this.AdvancedTagTabPage.ResumeLayout(false);
             this.gbxSoundEffectTag.ResumeLayout(false);
             this.gbxSoundEffectTag.PerformLayout();
             this.gbxCustomIconTag.ResumeLayout(false);
@@ -2808,7 +2798,7 @@ namespace MSBT_Editor
         public System.Windows.Forms.ToolStripMenuItem 開くToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem Msbt上書き保存ToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem Msbt保存ToolStripMenuItem;
-        public System.Windows.Forms.ToolStripMenuItem mSBF開くToolStripMenuItem;
+        public System.Windows.Forms.ToolStripMenuItem Msbf開くToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem Msbf上書き保存ToolStripMenuItem;
         public System.Windows.Forms.ToolStripMenuItem Msbf保存ToolStripMenuItem;
         public System.Windows.Forms.TabControl tabControl1;
@@ -2872,7 +2862,7 @@ namespace MSBT_Editor
         private System.Windows.Forms.Label lblMsbfFlow;
         public System.Windows.Forms.ComboBox cmbCharacterIconTag;
         public System.Windows.Forms.ComboBox cmbObjectIconTag;
-        public System.Windows.Forms.ComboBox cmbOthersIconTag;
+        public System.Windows.Forms.ComboBox cmbOtherIconTag;
         public System.Windows.Forms.GroupBox gbxRubiTag;
         public System.Windows.Forms.Button btnInsertRubiTag;
         public System.Windows.Forms.Label lblRubiTagKanjiCount;
@@ -2893,13 +2883,13 @@ namespace MSBT_Editor
         public System.Windows.Forms.Button btnInsertHourTag;
         public System.Windows.Forms.Button btnInsertVariableInt5DigitsTag;
         public System.Windows.Forms.Button btnInsertVariableInt4DigitsTag;
-        public System.Windows.Forms.Button btnInsertNumbersBelowDecimalPoint;
+        public System.Windows.Forms.Button btnInsertNumbersBelowDecimalPointTag;
         public System.Windows.Forms.Button btnInsertCharacterIconTag;
         public System.Windows.Forms.Label lblCharacterIconTag;
         public System.Windows.Forms.Button btnInsertObjectIconTag;
         public System.Windows.Forms.Label lblObjectIconTag;
-        public System.Windows.Forms.Button btnInsertOthersIconTag;
-        public System.Windows.Forms.Label lblOthersIconTag;
+        public System.Windows.Forms.Button btnInsertOtherIconTag;
+        public System.Windows.Forms.Label lblOtherIconTag;
         public System.Windows.Forms.Button btnInsertTotalPlayTimeTag;
         public System.Windows.Forms.Button btnInsertUserNameTag;
         public System.Windows.Forms.Button btnInsertScoreTag;
@@ -2914,7 +2904,7 @@ namespace MSBT_Editor
         private System.Windows.Forms.GroupBox gbxCreditDebugger;
         private System.Windows.Forms.Label lblCreditPorto;
         private System.Windows.Forms.Label lblCreditEvanbowl;
-        private System.Windows.Forms.Label lblCreditHiiraghi;
+        private System.Windows.Forms.Label lblCreditHiiragi;
         private System.Windows.Forms.Label lblCreditEigen;
         private System.Windows.Forms.Label lblCreditDossun;
         private System.Windows.Forms.Label lblCreditXenon;
@@ -2936,8 +2926,8 @@ namespace MSBT_Editor
         private System.Windows.Forms.TextBox txtSoundEffectName;
         public System.Windows.Forms.ListBox lstFilesInsideRarc;
         public System.Windows.Forms.Label lblSaveSystemDiscription;
-        public System.Windows.Forms.GroupBox gbxMsbtSettingsAtr1;
-        public System.Windows.Forms.TabPage AdvancedTagsTabPage;
+        public System.Windows.Forms.GroupBox gbxMsbtSettingAtr1;
+        public System.Windows.Forms.TabPage AdvancedTagTabPage;
         private System.Windows.Forms.GroupBox gbxCreditDebuggerVIP;
         private System.Windows.Forms.GroupBox gbxCreditContributor;
         private System.Windows.Forms.GroupBox gbxHowToUse;
@@ -2953,9 +2943,9 @@ namespace MSBT_Editor
         private System.Windows.Forms.LinkLabel llbGitHubReleasesUrl;
         private System.Windows.Forms.Label lblCurrentVersion;
         private System.Windows.Forms.GroupBox gbxCurrentVersion;
-        public System.Windows.Forms.ToolStripMenuItem ARC開くToolStripMenuItem;
-        public System.Windows.Forms.ToolStripMenuItem ARC上書き保存ToolStripMenuItem;
-        public System.Windows.Forms.ToolStripMenuItem ARC保存ToolStripMenuItem;
+        public System.Windows.Forms.ToolStripMenuItem Arc開くToolStripMenuItem;
+        public System.Windows.Forms.ToolStripMenuItem Arc上書き保存ToolStripMenuItem;
+        public System.Windows.Forms.ToolStripMenuItem Arc保存ToolStripMenuItem;
         public System.Windows.Forms.TabControl tabControl3;
         public System.Windows.Forms.TabPage tbpFilesInsideRarc;
         public System.Windows.Forms.Button btnInsertCustomIconTag;

--- a/MSBT_Editor/Form1.cs
+++ b/MSBT_Editor/Form1.cs
@@ -24,8 +24,8 @@ namespace MSBT_Editor
         private static Form1 _form1Instance;
 
         //開発専用のメニューを表示します
-        public static readonly bool UseDevelopMenue = true;
-        public static readonly bool UseDebugMenue = true;
+        public static readonly bool EnableDevelopMenu = true;
+        public static readonly bool EnableDebugMenu = true;
 
         private static bool s_useAutoSave = false;
 
@@ -41,13 +41,13 @@ namespace MSBT_Editor
         private void Msbt上書き保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.Save(Dialog.Save_Path_Msbt, 1);
 
 
-        private void MSBF開くToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.Open(2);
+        private void Msbf開くToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.Open(2);
         private void Msbf保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.SaveAs(2);
         private void Msbf上書き保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.Save(Dialog.Save_Path_Msbf, 2);
 
-        private void ARC開くToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.Open(3);
-        private void ARC保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.SaveAs(3);
-        private void ARC上書き保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.ArcSave();
+        private void Arc開くToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.Open(3);
+        private void Arc保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.SaveAs(3);
+        private void Arc上書き保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.ArcSave();
         #endregion
 
 
@@ -63,7 +63,7 @@ namespace MSBT_Editor
 
             //言語設定
             cmbLanguage.Text = Properties.Settings.Default.言語;
-            Langage.Langage_Check();
+            Language.Language_Check();
 
             chkShowTvwMsbfFlow.Checked = true;
 
@@ -92,9 +92,9 @@ namespace MSBT_Editor
             {
                 Dialog.FileCheck(item);
                 if ((stbOpenedMsbtName.Text
-                    == Langage.FileReadStatusJP[0]) ||
+                    == Language.FileReadStatusJP[0]) ||
                     (stbOpenedMsbtName.Text
-                    == Langage.FileReadStatusUS[0]))
+                    == Language.FileReadStatusUS[0]))
                     return;
                 string appPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
                 string msbtname = Path.GetFileNameWithoutExtension(stbOpenedMsbtName.Text);
@@ -107,7 +107,7 @@ namespace MSBT_Editor
 
         private void DebugFormPartsVisible()
         {
-            if (UseDebugMenue == false)
+            if (EnableDebugMenu == false)
             {
                 lblMsbfHashCalculator.Visible = false;
                 txtListNameToCalculateHash.Visible = false;
@@ -128,7 +128,7 @@ namespace MSBT_Editor
 
         private void DevFormPartsVisible()
         {
-            if (UseDevelopMenue == false)
+            if (EnableDevelopMenu == false)
             {
                 //ARC機能の非表示
                 //tabControl3.TabPages.Remove(tabPage12);
@@ -199,7 +199,7 @@ namespace MSBT_Editor
             txtSelectedMsbtListName.Text = lstListsInsideMsbt.Text;
             lblMsbtListSelectIndex.Text = "0x" + lstListsInsideMsbt.SelectedIndex.ToString("X");
 
-            if (UseDebugMenue == false) return;
+            if (EnableDebugMenu == false) return;
             //ハッシュスキップ数を表示
             var FindMsbtListTextIndexNum = LBL1.NameList.IndexOf(lstListsInsideMsbt.Text);
             if (-1 != FindMsbtListTextIndexNum)
@@ -212,7 +212,7 @@ namespace MSBT_Editor
             }
         }
 
-        private void TxtATR1SoundID_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1SoundID_TextChanged(object sender, EventArgs e)
         {
             if (lstListsInsideMsbt.Items.Count < 1) return;
             //Console.WriteLine(e.GetType().FullName);
@@ -669,10 +669,10 @@ namespace MSBT_Editor
             Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbObjectIconTag, IconTag);
         }
 
-        private void BtnInsertOthersIconTag_Click(object sender, EventArgs e)
+        private void BtnInsertOtherIconTag_Click(object sender, EventArgs e)
         {
             string[] IconTag = { "<Icon=\"Pointer\">", "<Icon=\"PointerYellow\">", "<Icon=\"PointerHand\">", "<Icon=\"WiiMote\">", "<Icon=\"AButton\">", "<Icon=\"BButton\">", "<Icon=\"CButton\">", "<Icon=\"ZButton\">", "<Icon=\"DPad\">", "<Icon=\"DPadDown\">", "<Icon=\"DPadUp\">", "<Icon=\"JoyStick\">", "<Icon=\"Nunchuck\">", "<Icon=\"Aim\">", "<Icon=\"MButton\">", "<Icon=\"PButton\">", "<Icon=\"XIcon\">", "<Icon=\"GreenComet\">", "<Icon=\"SilverCrown\">", "<Icon=\"SilverCrownwJewel\">", "<Icon=\"GoldCrown\">", "<Icon=\"Letter\">", "<Icon=\"ArrowDown\">", "<Icon=\"StopWatch\">", "<Icon=\"1Button\">", "<Icon=\"2Button\">", "<Icon=\"HomeButton\">", "<Icon=\"PointerGrip\">", "<Icon=\"PointerNonGrip\">", "<Icon=\"QuestionMark\">", "<Icon=\"YellowComet\">", "<Icon=\"GreenQuestionMark\">", "<Icon=\"EmptyStar\">", "<Icon=\"EmptyCometMedal\">", "<Icon=\"EmptyStarComet\">", "<Icon=\"HiddenStar\">", "<Icon=\"BronzeComet\">" };
-            Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbOthersIconTag, IconTag);
+            Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbOtherIconTag, IconTag);
         }
 
         private void BtnInsertVariableInt4DigitsTag_Click(object sender, EventArgs e)
@@ -710,7 +710,7 @@ namespace MSBT_Editor
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
-        private void BtnInsertNumbersBelowDecimalPoint_Click(object sender, EventArgs e)
+        private void BtnInsertNumbersBelowDecimalPointTag_Click(object sender, EventArgs e)
         {
             if (lstListsInsideMsbt.Items.Count < 1) return;
             string tag = "</AfterTheDecimalPoint>";
@@ -750,7 +750,7 @@ namespace MSBT_Editor
             {
                 case "0001":
                     lblFlw2Arg1.Text = "グループ番号";
-                    lblFlw2Arg2.Text = "Msbtテキストlist番号";
+                    lblFlw2Arg2.Text = "MSBTテキストlist番号";
                     lblFlw2Arg3.Text = "FLW2オフセット";
                     lblFlw2Arg4.Text = "不明5";
                     if (Properties.Settings.Default.言語 == "日本語") break;
@@ -887,7 +887,7 @@ namespace MSBT_Editor
             string[] fileName = (string[])e.Data.GetData(DataFormats.FileDrop, false);
             var filecount = fileName.Count();
 
-            if (UseDebugMenue == true)
+            if (EnableDebugMenu == true)
             {
                 MultipleFileRead(fileName, out bool readFiles);
                 if (readFiles == true) return;
@@ -927,16 +927,6 @@ namespace MSBT_Editor
             else e.Effect = DragDropEffects.None;
         }
 
-        private void textBox25_KeyPress(object sender, KeyPressEventArgs e)
-        {
-
-        }
-
-        private void textBox26_KeyPress(object sender, KeyPressEventArgs e)
-        {
-
-        }
-
         private void TxtFen1Arg0_TextChanged(object sender, EventArgs e)
         {
             FEN1.FEN1_Item_Change(lstListsInsideFen1, txtFen1Arg0);
@@ -971,28 +961,18 @@ namespace MSBT_Editor
 
         }
 
-        private void textBox30_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void TxtFen1ListName_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void BtnAddFlw2List_Click(object sender, EventArgs e)
         {
             FLW2 flw2 = new FLW2();
             if (lstListsInsideFlw2.Items.Count != 0)
             {
-                lstListsInsideFlw2.Items.Add(Langage.FLW2_List_Langage(4));
+                lstListsInsideFlw2.Items.Add(Language.FLW2_List_Language(4));
                 flw2.Item.Add(new FLW2.flw2_item(4, 0, 0, 0, 0, 0));
                 lstListsInsideFlw2.EndUpdate();
             }
             else
             {
-                lstListsInsideFlw2.Items.Add(Langage.FLW2_List_Langage(4));
+                lstListsInsideFlw2.Items.Add(Language.FLW2_List_Language(4));
                 flw2.Item = new List<FLW2.flw2_item>();
                 flw2.Item.Add(new FLW2.flw2_item(4, 0, 0, 0, 0, 0));
                 flw2.Branch_List_No = new List<int>();
@@ -1040,13 +1020,13 @@ namespace MSBT_Editor
 
                     //if (listBox2.Items.Count != 0)
                     //{
-                    //    listBox2.Items.Add(Langage.FLW2_List_Langage(4));
+                    //    listBox2.Items.Add(Language.FLW2_List_Language(4));
                     //    flw2.Item.Add(new FLW2.flw2_item(4, 0, list2count, 0, 0, 0));
                     //    listBox2.EndUpdate();
                     //}
                     //else
                     //{
-                    //    listBox2.Items.Add(Langage.FLW2_List_Langage(4));
+                    //    listBox2.Items.Add(Language.FLW2_List_Language(4));
                     //    flw2.Item = new List<FLW2.flw2_item>();
                     //    flw2.Item.Add(new FLW2.flw2_item(4, 0, list2count, 0, 0, 0));
                     //    flw2.Branch_List_No = new List<int>();
@@ -1075,13 +1055,13 @@ namespace MSBT_Editor
 
                     //if (listBox2.Items.Count != 0)
                     //{
-                    //    listBox2.Items.Add(Langage.FLW2_List_Langage(4));
+                    //    listBox2.Items.Add(Language.FLW2_List_Language(4));
                     //    flw2.Item.Add(new FLW2.flw2_item(4, 0, list2count, 0, 0, 0));
                     //    listBox2.EndUpdate();
                     //}
                     //else
                     //{
-                    //    listBox2.Items.Add(Langage.FLW2_List_Langage(4));
+                    //    listBox2.Items.Add(Language.FLW2_List_Language(4));
                     //    flw2.Item = new List<FLW2.flw2_item>();
                     //    flw2.Item.Add(new FLW2.flw2_item(4, 0, list2count, 0, 0, 0));
                     //    flw2.Branch_List_No = new List<int>();
@@ -1116,11 +1096,6 @@ namespace MSBT_Editor
             }
         }
 
-        private void TxtMsbtListName_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void CmbLanguage_SelectedIndexChanged(object sender, EventArgs e)
         {
             switch (cmbLanguage.SelectedIndex)
@@ -1137,10 +1112,10 @@ namespace MSBT_Editor
             }
 
             Properties.Settings.Default.Save();
-            Formsys.Langage.Langage_Check();
+            Formsys.Language.Language_Check();
         }
 
-        public static TreeNode Tvparenfinder(TreeView tv)
+        public static TreeNode TreeViewParentFinder(TreeView tv)
         {
             var rootnode = tv.SelectedNode;
             //this.textBox25.TextChanged -= new EventHandler(this.textBox25_TextChanged)
@@ -1159,7 +1134,7 @@ namespace MSBT_Editor
             if (tvwMsbfFlow.SelectedNode.Tag == default) return;
 
             //var oldindex = MsbfTreeView.SelectedNode;
-            var rootnode = Form1.Tvparenfinder(tvwMsbfFlow);
+            var rootnode = Form1.TreeViewParentFinder(tvwMsbfFlow);
 
             var rootnodelistbox3find = 0;
             if (lstListsInsideFen1.Items.Count != 0)
@@ -1241,14 +1216,14 @@ namespace MSBT_Editor
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
-        private void textBox32_TextChanged(object sender, EventArgs e)
+        private void TextBox32_TextChanged(object sender, EventArgs e)
         {
             var strbytes = Encoding.GetEncoding("utf-16BE").GetBytes(textBox32.Text);
             textBox33.Text = "";
             foreach (var hexbit in strbytes) textBox33.AppendText(Environment.NewLine + hexbit.ToString("X2"));
         }
 
-        private void button30_Click(object sender, EventArgs e)
+        private void Button30_Click(object sender, EventArgs e)
         {
             //if (richTextBox1.Text.Contains("<Icon=\"AButton\">"))
             //{
@@ -1310,27 +1285,6 @@ namespace MSBT_Editor
             }
         }
 
-        private void textBox33_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-        private void TxtListNameToCalculateHash_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
-
-
-        private void StbOpenedRarcName_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void LblMsbfHashCalculator_Click(object sender, EventArgs e)
-        {
-
-        }
         //ATR1セクションテキストボックスのキープレスイベント
         private void TxtAtr1SoundID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
@@ -1351,7 +1305,7 @@ namespace MSBT_Editor
             KeyPressEventSupport.CanWriteChar(e, true);
         }
 
-        private void textBox30_MouseClick(object sender, MouseEventArgs e)
+        private void TxtSelectedMsbtListName_MouseClick(object sender, MouseEventArgs e)
         {
             this.txtSelectedMsbtListName.SelectAll();
         }
@@ -1376,14 +1330,8 @@ namespace MSBT_Editor
             Calculation_System.TextBoxInsert(txtMsbtText, Tag);
         }
 
-        private void UserIconInsertTextBox_TextChanged(object sender, EventArgs e)
-        {
-
-        }
-
         private void UserIconInsertTextBox_KeyPress(object sender, KeyPressEventArgs e)
         {
-
             KeyPressEventSupport.OnlyHexChar(e, true);
         }
 
@@ -1399,11 +1347,6 @@ namespace MSBT_Editor
 
             Tag = "<SE=\"" + Tag + "\">";
             Calculation_System.TextBoxInsert(txtMsbtText, Tag);
-        }
-
-        private void TxtReadOnlyMsbtText_TextChanged(object sender, EventArgs e)
-        {
-
         }
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
@@ -1442,11 +1385,6 @@ namespace MSBT_Editor
         {
             this.llbSMG2HackDiscordUrl.LinkVisited = true;
             System.Diagnostics.Process.Start("https://discord.gg/B4EwY7h");
-        }
-
-        private void Form1_KeyPress(object sender, KeyPressEventArgs e)
-        {
-
         }
 
         private void TxtFlw2FlowType_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
@@ -1533,14 +1471,14 @@ namespace MSBT_Editor
             bool IsMsbtDef = false;
             bool IsMsbfDef = false;
 
-            if (MsbtOldName == Langage.FileReadStatusJP[0]) IsMsbtDef = true;
-            if (MsbfOldName == Langage.FileReadStatusJP[1]) IsMsbfDef = true;
+            if (MsbtOldName == Language.FileReadStatusJP[0]) IsMsbtDef = true;
+            if (MsbfOldName == Language.FileReadStatusJP[1]) IsMsbfDef = true;
 
 
             if (Properties.Settings.Default.言語 == "EN")
             {
-                if (MsbtOldName == Langage.FileReadStatusUS[0]) IsMsbtDef = true;
-                if (MsbfOldName == Langage.FileReadStatusUS[1]) IsMsbfDef = true;
+                if (MsbtOldName == Language.FileReadStatusUS[0]) IsMsbtDef = true;
+                if (MsbfOldName == Language.FileReadStatusUS[1]) IsMsbfDef = true;
             }
 
             if ((PathExtention == ".msbt") && (Dialog.Save_Path_Msbt != lstFilesInsideRarc.Text))
@@ -1622,8 +1560,11 @@ namespace MSBT_Editor
             }
 
             //MSBTの内容を一度全て消す
-            txtMsbtText.Clear();
-            txtReadOnlyMsbtText.Clear();
+            if (PathExtention == ".msbt")    //MSBF読み込み時に、MSBT_Data.MSBT_All_Data.Text[]の最後の要素に""が代入されてしまうのを防ぐため
+            {
+                txtMsbtText.Clear();
+                txtReadOnlyMsbtText.Clear();
+            }
             txtAtr1SoundID.Clear();
             txtAtr1SimpleCamID.Clear();
             txtAtr1DialogID.Clear();
@@ -1662,7 +1603,6 @@ namespace MSBT_Editor
 
         private void LstFilesInsideRarc_ChangeUICues(object sender, UICuesEventArgs e)
         {
-
             Console.WriteLine(lstFilesInsideRarc.SelectedValue);
         }
     }

--- a/MSBT_Editor/Formsys/Language.cs
+++ b/MSBT_Editor/Formsys/Language.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 
 namespace MSBT_Editor.Formsys
 {
-    public class Langage : objects
+    public class Language : objects
     {
         private static readonly string[] IconNameJP01 = { "ピーチ", "クッパ", "キノピオ", "マリオ", "マリオ2", "チコ", "ヨッシー", "腹ペコチコ", "ルイージ", "ベビーチコ", "アシストチコ", "ベーゴマン", "クリボー", "星ウサギ" };
         private static readonly string[] IconNameJP02 = { "彗星メダル", "コイン×3", "カラフルスターピース", "イエローチップ", "スターピース紫", "シルバースター", "スター", "グランドスター", "ブロンズスター", "コイン", "パープルコイン", "1UPキノコ", "ライフアップキノコ", "ブルースター", "スターリング", "ヨッシーキャプチャー花", "ココナッツ", "ブルーチップ", "バルーンフルーツ", "中間ポイント", "グランドブロンズスター" };
@@ -15,10 +15,10 @@ namespace MSBT_Editor.Formsys
         
         //<>で挟んでいる理由は、ファイル名に<>を付けることが出来ないので付けています。
         //<>を付けることにより、ファイルを読み込んでいるときにこの項目を削除させない意図があります。
-        public static readonly string[] FileReadStatusJP = { "<Msbtファイルなし>","<Msbfファイルなし>","<Arcファイルなし>" } ;
+        public static readonly string[] FileReadStatusJP = { "<MSBTファイルなし>","<MSBFファイルなし>","<ARCファイルなし>" } ;
         public static readonly string[] FileReadStatusUS = { "<No MSBT Open>", "<No MSBF Open>", "<No ARC Open>" };
 
-        public static void Langage_Check()
+        public static void Language_Check()
         {
             switch (Properties.Settings.Default.言語)
             {
@@ -44,7 +44,7 @@ namespace MSBT_Editor.Formsys
             }
         }
 
-        public static string FLW2_List_Langage(int num) {
+        public static string FLW2_List_Language(int num) {
             switch (Properties.Settings.Default.言語)
             {
                 case "日本語":
@@ -106,7 +106,7 @@ namespace MSBT_Editor.Formsys
         public static void JP(){
             tssl1.Text = "開いたファイル：";
             tssl6.Text = "保存したファイル：";
-            //menue
+            //menu
             tlmi_file.Text = "ファイル";
             tlmi_msbt_open.Text = "開く";
             tlmi_msbt_save.Text = "MSBT上書き保存";
@@ -131,7 +131,7 @@ namespace MSBT_Editor.Formsys
             tabp12.Text = "ARCファイルの中身";
             tabp14.Text = "情報";
 
-            AdvancedTagsTabPage.Text = "上級者向けタグ";
+            AdvancedTagTabPage.Text = "上級者向けタグ";
             //label
             labeltxt01.Text = "NPCボイス";
             labeltxt02.Text = "カメラ";
@@ -139,13 +139,13 @@ namespace MSBT_Editor.Formsys
             labeltxt04.Text = "ウィンドウタイプ";
             labeltxt05.Text = "イベントカメラID";
             labeltxt06.Text = "会話制御エリア Obj_arg0";
-            labeltxt07.Text = "分からない6";
+            labeltxt07.Text = "不明6";
             labeltxt08.Text = "特殊テキストオフセット";
             labeltxt09.Text = "特殊テキスト(基本null) ※上級者以外触らない";
             labeltxt10.Text = "タグインデックス？";
             labeltxt11.Text = "追加するMSBTリスト名";
             labeltxt12.Text = "削除は対象のリスト選択後に" + Environment.NewLine + "右の削除ボタンを押す";
-            labeltxt13.Text = "※ゲームの命名規則を守ってください";
+            labeltxt13.Text = "※ゲーム内での命名規則を守ってください";
             labeltxt15.Text = "※初心者は触らないでください" + Environment.NewLine + "データが破損する恐れあり";
             labeltxt17.Text = "ふりがなの数";
             labeltxt18.Text = "漢字の数";
@@ -161,24 +161,26 @@ namespace MSBT_Editor.Formsys
             labeltxt27.Text = "不明4";
             labeltxt28.Text = "不明5";
 
-            labeltxt29.Text = "ジャンプ先1";
-            labeltxt30.Text = "ジャンプ先2";
-            labeltxt33.Text = "※まだすべての機能が解明できていないので" + Environment.NewLine + "不具合が発生する可能性があります";
+            labeltxt29.Text = "ジャンプ先1（真）";
+            labeltxt30.Text = "ジャンプ先2（偽）";
+            labeltxt33.Text = "※まだすべての機能を解明できていないため、" + Environment.NewLine + "　不具合が発生する可能性があります";
             labeltxt34.Text = "この項目は名前が不要です";
             labeltxt35.Text = "名前必須(Flowなどを省いた名前)";
             labeltxt31.Text = "不明";
             labeltxt32.Text = "FLW2開始インデックス";
             labeltxt39.Text = "この項目が　0　の場合"+ Environment.NewLine +"ゲームにテキストが認識されません";
             Label58.Text 
-                = "ARCファイルから開いた" 
+                = "ARCファイルから開いたMSBTやMSBFの" 
                 + Environment.NewLine 
-                + "MsbtやMsbfの内容を変更した際は上書き保存をしてください。" 
+                + "内容を変更した際は、上書き保存をしてください。" 
                 + Environment.NewLine 
-                + "上書き保存してからリストを選択し直さないと、変更が保存されません。" 
+                + "上書き保存してからリストを選択し直さないと、" 
                 + Environment.NewLine 
+                + "変更が保存されません。"
+                + Environment.NewLine
                 + "全ての変更が終わったらARCを保存してください。"
                 + Environment.NewLine
-                + "※MSBT,MSBF以外は表示されません";
+                + "※MSBT, MSBF以外は表示されません";
 
             UserIconInsertLabel1.Text 
                 = "アイコンを作成した場合のみ使用可能"
@@ -198,7 +200,7 @@ namespace MSBT_Editor.Formsys
                 + "例： SE_BV_KOOPA_BURN_RUN";
 
             //groupbox
-            Atr1GroupBox.Text = "選択されたMsbtメッセージの詳細設定";
+            Atr1GroupBox.Text = "選択されたMSBTメッセージの詳細設定";
             groupbox3.Text = "各セクションのエントリーサイズ";
             groupbox4.Text = "ルビ";
             groupbox5.Text = "タイマー";
@@ -311,7 +313,7 @@ namespace MSBT_Editor.Formsys
             tabp12.Text = "Contents of ARC file";
             tabp14.Text = "Info";
 
-            AdvancedTagsTabPage.Text = "Advanced Tags";
+            AdvancedTagTabPage.Text = "Advanced Tags";
             //label
             labeltxt01.Text = "Sound ID";
             labeltxt02.Text = "Camera";

--- a/MSBT_Editor/Formsys/objects.cs
+++ b/MSBT_Editor/Formsys/objects.cs
@@ -34,13 +34,13 @@ namespace MSBT_Editor.Formsys
         protected static Button button10 = Form1.Form1Instance.btnInsertResultScenarioNameTag;
         protected static Button button11 = Form1.Form1Instance.btnInsertCharacterIconTag;
         protected static Button button12 = Form1.Form1Instance.btnInsertObjectIconTag;
-        protected static Button button13 = Form1.Form1Instance.btnInsertOthersIconTag;
+        protected static Button button13 = Form1.Form1Instance.btnInsertOtherIconTag;
         protected static Button button14 = Form1.Form1Instance.btnInsertVariableInt4DigitsTag;
         protected static Button button15 = Form1.Form1Instance.btnInsertVariableInt5DigitsTag;
         protected static Button button16 = Form1.Form1Instance.btnInsertHourTag;
         protected static Button button17 = Form1.Form1Instance.btnInsertMinuteTag;
         protected static Button button18 = Form1.Form1Instance.btnInsertSecondTag;
-        protected static Button button19 = Form1.Form1Instance.btnInsertNumbersBelowDecimalPoint;
+        protected static Button button19 = Form1.Form1Instance.btnInsertNumbersBelowDecimalPointTag;
 
         protected static Button button21 = Form1.Form1Instance.btnAddFlw2List;
         protected static Button button22 = Form1.Form1Instance.btnDeleteFlw2List;
@@ -81,7 +81,7 @@ namespace MSBT_Editor.Formsys
         //label 20～29
         protected static Label labeltxt20 = Form1.Form1Instance.lblCharacterIconTag;
         protected static Label labeltxt21 = Form1.Form1Instance.lblObjectIconTag;
-        protected static Label labeltxt22 = Form1.Form1Instance.lblOthersIconTag;
+        protected static Label labeltxt22 = Form1.Form1Instance.lblOtherIconTag;
         protected static Label labeltxt23 = Form1.Form1Instance.lblFlw2FlowType;
         protected static Label labeltxt24 = Form1.Form1Instance.lblFlw2Padding;
         protected static Label labeltxt25 = Form1.Form1Instance.lblFlw2Arg1;
@@ -126,10 +126,10 @@ namespace MSBT_Editor.Formsys
         protected static ComboBox combo4 = Form1.Form1Instance.cmbCenterTag;
         protected static ComboBox combo5 = Form1.Form1Instance.cmbCharacterIconTag;
         protected static ComboBox combo6 = Form1.Form1Instance.cmbObjectIconTag;
-        protected static ComboBox combo7 = Form1.Form1Instance.cmbOthersIconTag;
+        protected static ComboBox combo7 = Form1.Form1Instance.cmbOtherIconTag;
 
         //groupbox
-        protected static GroupBox Atr1GroupBox = Form1.Form1Instance.gbxMsbtSettingsAtr1;
+        protected static GroupBox Atr1GroupBox = Form1.Form1Instance.gbxMsbtSettingAtr1;
         protected static GroupBox groupbox3 = Form1.Form1Instance.gbxCreditSectionEntrySize;
         protected static GroupBox groupbox4 = Form1.Form1Instance.gbxRubiTag;
         protected static GroupBox groupbox5 = Form1.Form1Instance.gbxTimerTag;
@@ -146,7 +146,7 @@ namespace MSBT_Editor.Formsys
         protected static TabPage tabp2 = Form1.Form1Instance.tbpMsbtTextEdit;
         protected static TabPage tabp3 = Form1.Form1Instance.tbpListEdit;
         protected static TabPage tabp4 = Form1.Form1Instance.tbpMsbfSetting;
-        protected static TabPage AdvancedTagsTabPage = Form1.Form1Instance.AdvancedTagsTabPage;
+        protected static TabPage AdvancedTagTabPage = Form1.Form1Instance.AdvancedTagTabPage;
 
         protected static TabPage tabp6 = Form1.Form1Instance.tbpGeneralTag;
         protected static TabPage tabp7 = Form1.Form1Instance.tbpValueTag;
@@ -160,12 +160,12 @@ namespace MSBT_Editor.Formsys
         protected static ToolStripMenuItem tlmi_msbt_open = Form1.Form1Instance.開くToolStripMenuItem;
         protected static ToolStripMenuItem tlmi_msbt_save = Form1.Form1Instance.Msbt上書き保存ToolStripMenuItem;
         protected static ToolStripMenuItem tlmi_msbt_save_as = Form1.Form1Instance.Msbt保存ToolStripMenuItem;
-        protected static ToolStripMenuItem tlmi_msbf_open = Form1.Form1Instance.mSBF開くToolStripMenuItem;
+        protected static ToolStripMenuItem tlmi_msbf_open = Form1.Form1Instance.Msbf開くToolStripMenuItem;
         protected static ToolStripMenuItem tlmi_msbf_save = Form1.Form1Instance.Msbf上書き保存ToolStripMenuItem;
         protected static ToolStripMenuItem tlmi_msbf_save_as = Form1.Form1Instance.Msbf保存ToolStripMenuItem;
-        protected static ToolStripMenuItem tlmi_arc_open = Form1.Form1Instance.ARC開くToolStripMenuItem;
-        protected static ToolStripMenuItem tlmi_arc_save = Form1.Form1Instance.ARC上書き保存ToolStripMenuItem;
-        protected static ToolStripMenuItem tlmi_arc_save_as = Form1.Form1Instance.ARC保存ToolStripMenuItem;
+        protected static ToolStripMenuItem tlmi_arc_open = Form1.Form1Instance.Arc開くToolStripMenuItem;
+        protected static ToolStripMenuItem tlmi_arc_save = Form1.Form1Instance.Arc上書き保存ToolStripMenuItem;
+        protected static ToolStripMenuItem tlmi_arc_save_as = Form1.Form1Instance.Arc保存ToolStripMenuItem;
 
         //stats
         protected static ToolStripStatusLabel tssl1 = Form1.Form1Instance.stbStatusLabel;

--- a/MSBT_Editor/MSBFsys/MSBF_Header.cs
+++ b/MSBT_Editor/MSBFsys/MSBF_Header.cs
@@ -14,8 +14,6 @@ namespace MSBT_Editor.MSBFsys
     {
         public void Read(string path)
         {
-            
-
             list2.Items.Clear();
             list3.Items.Clear();
             FileStream fs = new FileStream(path, FileMode.Open);

--- a/MSBT_Editor/MSBT_Editor.csproj
+++ b/MSBT_Editor/MSBT_Editor.csproj
@@ -76,7 +76,7 @@
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
     <Compile Include="Formsys\KeyPressEventSupport.cs" />
-    <Compile Include="Formsys\Langage.cs" />
+    <Compile Include="Formsys\Language.cs" />
     <Compile Include="Formsys\objects.cs" />
     <Compile Include="MSBX\IMSBX_Data.cs" />
     <Compile Include="MSBFsys\MSBF_Data.cs" />

--- a/MSBT_Editor/MSBTsys/MSBT_Header.cs
+++ b/MSBT_Editor/MSBTsys/MSBT_Header.cs
@@ -14,7 +14,6 @@ namespace MSBT_Editor.MSBTsys
 {
     public class MSBT_Header : MSBT_Data
     {
-        
         public void Read(string path)
         {
             FileStream fs = new FileStream(path, FileMode.Open);
@@ -49,8 +48,7 @@ namespace MSBT_Editor.MSBTsys
             Atr1SpecialText = new List<string>();
             Atr1SpecialText = ATR1.SpecialTextList;
 
-            if(MsbtListBox.Items.Count > 0)
-            MsbtListBox.SelectedIndex = 0;
+            if (MsbtListBox.Items.Count > 0) MsbtListBox.SelectedIndex = 0;
 
             //終了処理
             fs.Close();

--- a/MSBT_Editor/Sectionsys/FEN1.cs
+++ b/MSBT_Editor/Sectionsys/FEN1.cs
@@ -280,7 +280,7 @@ namespace MSBT_Editor.Sectionsys
                 treeview1.Nodes.Add(item.Value.tagname);
                 
                 //エントリーポイントをサブノードに追加
-                treeviewnodeadder(flw2item, treeview1.Nodes[item.Index]);
+                TreeViewNodeAdder(flw2item, treeview1.Nodes[item.Index]);
             }
         }
 
@@ -289,7 +289,7 @@ namespace MSBT_Editor.Sectionsys
         {
             FLW2 flw2 = new FLW2();
             var subnode_element = flw2.Item[subfunc];
-            subnodename = Langage.FLW2_List_Langage(subnode_element.TypeCheck);
+            subnodename = Language.FLW2_List_Language(subnode_element.TypeCheck);
 
             switch (type)
             {
@@ -380,7 +380,7 @@ namespace MSBT_Editor.Sectionsys
             
         }
 
-        public static void treeviewnodeadder(FLW2.flw2_item flw2item, TreeNode tn, int brancno = 0)
+        public static void TreeViewNodeAdder(FLW2.flw2_item flw2item, TreeNode tn, int brancno = 0)
         {
             tn.Tag = flw2item;
             //構文をサブノードに追加する
@@ -388,7 +388,7 @@ namespace MSBT_Editor.Sectionsys
             FLW2 flw2 = new FLW2();
             var subfunc = flw2item.Unknown2;
             var subnode_element = flw2.Item[subfunc];
-            var subnodename = Langage.FLW2_List_Langage(subnode_element.TypeCheck);
+            var subnodename = Language.FLW2_List_Language(subnode_element.TypeCheck);
             //AllJumpAddres.Add(subnode_element.Unknown2);
             TreeView_Fllow_Type_Checker(subfunc, subnode_element.TypeCheck, subnodename, tn);
             //return 0;
@@ -403,7 +403,7 @@ namespace MSBT_Editor.Sectionsys
 
             var subfunc = flw2item.Unknown4;
             var subnode_element = flw2.Item[subfunc];
-            var subnodename = Langage.FLW2_List_Langage(subnode_element.TypeCheck);
+            var subnodename = Language.FLW2_List_Language(subnode_element.TypeCheck);
             TreeView_Fllow_Type_Checker(subfunc, subnode_element.TypeCheck, subnodename, tn);
             
         }
@@ -417,7 +417,7 @@ namespace MSBT_Editor.Sectionsys
             subfunc += brancno;
             var subbranchfunc = flw2.Branch_No[subfunc];
             var subnode_element = flw2.Item[subbranchfunc];
-            var subnodename = Langage.FLW2_List_Langage(subnode_element.TypeCheck);
+            var subnodename = Language.FLW2_List_Language(subnode_element.TypeCheck);
             TreeView_Fllow_Type_Checker(subbranchfunc, subnode_element.TypeCheck, subnodename, tn);
         }
 
@@ -430,7 +430,7 @@ namespace MSBT_Editor.Sectionsys
             var subfunc = flw2item.Unknown3;
             //Console.WriteLine("" + subfunc.ToString("X"));
             var subnode_element = flw2.Item[subfunc];
-            var subnodename = Langage.FLW2_List_Langage(subnode_element.TypeCheck);
+            var subnodename = Language.FLW2_List_Language(subnode_element.TypeCheck);
             TreeView_Fllow_Type_Checker(subfunc, subnode_element.TypeCheck, subnodename, tn);
             
         }

--- a/MSBT_Editor/Sectionsys/FLW2.cs
+++ b/MSBT_Editor/Sectionsys/FLW2.cs
@@ -239,7 +239,7 @@ namespace MSBT_Editor.Sectionsys
             
             switch (num) {
                 case 0x0001:
-                    str = Langage.FLW2_List_Langage(num);
+                    str = Language.FLW2_List_Language(num);
                     //labeltxt25.Text = "FLW2ジャンプ先";
                     if (delete_flag == true)
                     {
@@ -247,7 +247,7 @@ namespace MSBT_Editor.Sectionsys
                     }
                     break;
                 case 0x0002:
-                    str = Langage.FLW2_List_Langage(num);
+                    str = Language.FLW2_List_Language(num);
                     //labeltxt25.Text = "固定";
                     if (delete_flag == false)
                     {
@@ -258,14 +258,14 @@ namespace MSBT_Editor.Sectionsys
 
                     break;
                 case 0x0003:
-                    str = Langage.FLW2_List_Langage(num);
+                    str = Language.FLW2_List_Language(num);
                     if (delete_flag == true)
                     {
                         branch_list_no.RemoveAt(FLW2.branch_list_no.IndexOf(index));
                     }
                     break;
                 case 0x0004:
-                    str = Langage.FLW2_List_Langage(num);
+                    str = Language.FLW2_List_Language(num);
                     if (delete_flag == true)
                     {
                         branch_list_no.RemoveAt(FLW2.branch_list_no.IndexOf(index));
@@ -420,17 +420,17 @@ namespace MSBT_Editor.Sectionsys
                         switch (/*flw2.Item[index].TypeCheck*/numhex)
                         {
                             case 1:
-                                lb.Items[index] = Langage.FLW2_List_Langage(1);
+                                lb.Items[index] = Language.FLW2_List_Language(1);
 
                                 break;
                             case 2:
-                                lb.Items[index] = Langage.FLW2_List_Langage(2);
+                                lb.Items[index] = Language.FLW2_List_Language(2);
                                 break;
                             case 3:
-                                lb.Items[index] = Langage.FLW2_List_Langage(3);
+                                lb.Items[index] = Language.FLW2_List_Language(3);
                                 break;
                             case 4:
-                                lb.Items[index] = Langage.FLW2_List_Langage(4);
+                                lb.Items[index] = Language.FLW2_List_Language(4);
                                 break;
                             default:
                                 lb.Items[index] = "エラーデータ「正しいデータを読み込んで」";


### PR DESCRIPTION
## 概要
- RARCファイルを開き、XXXX.msbt, XXXX.msbf, XXXX.msbtの順に読み込んだ際に、System.IO.EndOfStreamExceptionが発生する不具合を修正
- フォームのコントロール群の名前をリファクタリング
- language, menuのスペルミスを修正
- 一部ラベルのテキストを編集
- Form1.cs中の、不要なメソッドを削除

## 不具合詳細
2023-10-11のコミットで`Form1.LstFilesInsideRarc_SelectedIndexChanged`に追加された、MSBTの内容を一度全て消す処理における`txtMsbtText.Clear();`に起因する不具合
1. `txtMsbtText.Clear();`がXXXX.msbf読み込み時にも実行され、`txtMsbtText.Text == ""`となる
2. `MSBT_Data.MSBT_All_Data.Text[]`の最後の要素に""が代入されてしまう
3. 続けて再度XXXX.msbtを読み込む際にも、`MSBT_Data.MSBT_All_Data.Text[]`の最後の要素は""のまま
4. `MSBT_Data.MSBT_All_Data.Text[]`の最後の要素が""であることにより、`MSBT_Header.Read`でインスタンス化されたfsのLengthが本来よりも小さい値となってしまう
5. XXXX.msbtを読み込む途中で、`br.BaseStream.Position`が`br.BaseStream.Length`より大きな値となり、System.IO.EndOfStreamExceptionが発生する

## 変更内容
`if (PathExtention == ".msbt") {}`で`txtMsbtText.Clear();`と`txtReadOnlyMsbtText.Clear();`を覆い、MSBFファイル読み込み時に、`MSBT_Data.MSBT_All_Data.Text[]`の最後の要素に""が代入されてしまうのを防ぐ