### PR TITLE
 テキストボックスによるATR1の引数変更が反映されない不具合を修正

### DIFF
--- a/MSBT_Editor/FileSys/Calculation_System.cs
+++ b/MSBT_Editor/FileSys/Calculation_System.cs
@@ -754,7 +754,8 @@ namespace MSBT_Editor.FileSys
         public static byte[] StringToBytes(string str)
         {
             var bs = new List<byte>();
-            for (int i = 0; i < str.Length / 2; i++)
+            int halfLength = str.Length / 2;
+            for (int i = 0; i < halfLength; i++)
             {
                 bs.Add(Convert.ToByte(str.Substring(i * 2, 2), 16));
             }
@@ -811,8 +812,9 @@ namespace MSBT_Editor.FileSys
             oldstr = oldstr.Replace("\r", "");
             char[] ch = { '<', '>' };
             string[] oldstrarray = oldstr.Split(ch);
-            
-            for (int i = 0; i < oldstrarray.Count(); i++) {
+
+            int count = oldstrarray.Count();
+            for (int i = 0; i < count; i++) {
                 var roopstr = TagChecker(oldstrarray[i]);
                 oldstrarray[i] = roopstr;
             }

--- a/MSBT_Editor/Form1.Designer.cs
+++ b/MSBT_Editor/Form1.Designer.cs
@@ -67,14 +67,14 @@ namespace MSBT_Editor
             this.lblAtr1EventCameraID = new System.Windows.Forms.Label();
             this.lblAtr1WindowID = new System.Windows.Forms.Label();
             this.lblAtr1DialogID = new System.Windows.Forms.Label();
-            this.lblAtr1SimpleCamID = new System.Windows.Forms.Label();
+            this.lblAtr1SimpleCameraID = new System.Windows.Forms.Label();
             this.lblAtr1SoundID = new System.Windows.Forms.Label();
             this.txtAtr1Unknown6 = new System.Windows.Forms.TextBox();
             this.txtAtr1MessageAreaID = new System.Windows.Forms.TextBox();
             this.txtAtr1EventCameraID = new System.Windows.Forms.TextBox();
             this.txtAtr1WindowID = new System.Windows.Forms.TextBox();
             this.txtAtr1DialogID = new System.Windows.Forms.TextBox();
-            this.txtAtr1SimpleCamID = new System.Windows.Forms.TextBox();
+            this.txtAtr1SimpleCameraID = new System.Windows.Forms.TextBox();
             this.txtAtr1SoundID = new System.Windows.Forms.TextBox();
             this.tbpMsbtTextEdit = new System.Windows.Forms.TabPage();
             this.tabControl2 = new System.Windows.Forms.TabControl();
@@ -558,14 +558,14 @@ namespace MSBT_Editor
             this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1EventCameraID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1WindowID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1DialogID);
-            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1SimpleCamID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1SimpleCameraID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.lblAtr1SoundID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1Unknown6);
             this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1MessageAreaID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1EventCameraID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1WindowID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1DialogID);
-            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1SimpleCamID);
+            this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1SimpleCameraID);
             this.gbxMsbtSettingAtr1.Controls.Add(this.txtAtr1SoundID);
             this.gbxMsbtSettingAtr1.Location = new System.Drawing.Point(6, 6);
             this.gbxMsbtSettingAtr1.Name = "gbxMsbtSettingAtr1";
@@ -640,12 +640,12 @@ namespace MSBT_Editor
             // 
             // lblAtr1SimpleCamID
             // 
-            this.lblAtr1SimpleCamID.AutoSize = true;
-            this.lblAtr1SimpleCamID.Location = new System.Drawing.Point(6, 46);
-            this.lblAtr1SimpleCamID.Name = "lblAtr1SimpleCamID";
-            this.lblAtr1SimpleCamID.Size = new System.Drawing.Size(30, 12);
-            this.lblAtr1SimpleCamID.TabIndex = 9;
-            this.lblAtr1SimpleCamID.Text = "カメラ";
+            this.lblAtr1SimpleCameraID.AutoSize = true;
+            this.lblAtr1SimpleCameraID.Location = new System.Drawing.Point(6, 46);
+            this.lblAtr1SimpleCameraID.Name = "lblAtr1SimpleCamID";
+            this.lblAtr1SimpleCameraID.Size = new System.Drawing.Size(30, 12);
+            this.lblAtr1SimpleCameraID.TabIndex = 9;
+            this.lblAtr1SimpleCameraID.Text = "カメラ";
             // 
             // lblAtr1SoundID
             // 
@@ -707,13 +707,13 @@ namespace MSBT_Editor
             // 
             // txtAtr1SimpleCamID
             // 
-            this.txtAtr1SimpleCamID.Location = new System.Drawing.Point(147, 43);
-            this.txtAtr1SimpleCamID.MaxLength = 2;
-            this.txtAtr1SimpleCamID.Name = "txtAtr1SimpleCamID";
-            this.txtAtr1SimpleCamID.Size = new System.Drawing.Size(100, 19);
-            this.txtAtr1SimpleCamID.TabIndex = 1;
-            this.txtAtr1SimpleCamID.TextChanged += new System.EventHandler(this.TxtAtr1SimpleCamID_TextChanged);
-            this.txtAtr1SimpleCamID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1SimpleCamID_KeyPress);
+            this.txtAtr1SimpleCameraID.Location = new System.Drawing.Point(147, 43);
+            this.txtAtr1SimpleCameraID.MaxLength = 2;
+            this.txtAtr1SimpleCameraID.Name = "txtAtr1SimpleCameraID";
+            this.txtAtr1SimpleCameraID.Size = new System.Drawing.Size(100, 19);
+            this.txtAtr1SimpleCameraID.TabIndex = 1;
+            this.txtAtr1SimpleCameraID.TextChanged += new System.EventHandler(this.TxtAtr1SimpleCameraID_TextChanged);
+            this.txtAtr1SimpleCameraID.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.TxtAtr1SimpleCameraID_KeyPress);
             // 
             // txtAtr1SoundID
             // 
@@ -2748,7 +2748,7 @@ namespace MSBT_Editor
         private System.Windows.Forms.TextBox txtAtr1EventCameraID;
         private System.Windows.Forms.TextBox txtAtr1WindowID;
         private System.Windows.Forms.TextBox txtAtr1DialogID;
-        private System.Windows.Forms.TextBox txtAtr1SimpleCamID;
+        private System.Windows.Forms.TextBox txtAtr1SimpleCameraID;
         private System.Windows.Forms.TextBox txtAtr1SoundID;
         private System.Windows.Forms.TextBox txtLbl1TagIndex;
         public System.Windows.Forms.TextBox txtFlw2DebugHex;
@@ -2812,7 +2812,7 @@ namespace MSBT_Editor
         public System.Windows.Forms.Label lblAtr1EventCameraID;
         public System.Windows.Forms.Label lblAtr1WindowID;
         public System.Windows.Forms.Label lblAtr1DialogID;
-        public System.Windows.Forms.Label lblAtr1SimpleCamID;
+        public System.Windows.Forms.Label lblAtr1SimpleCameraID;
         public System.Windows.Forms.Label lblAtr1SoundID;
         public System.Windows.Forms.Label lblAtr1SpecialText;
         public System.Windows.Forms.Label lblLbl1TagIndex;

--- a/MSBT_Editor/Form1.cs
+++ b/MSBT_Editor/Form1.cs
@@ -141,10 +141,8 @@ namespace MSBT_Editor
 
         public static int ListBoxIndex_NegativeThenSetIndexZero(ListBox lb)
         {
-            if ((lb.SelectedIndex < 0))
-                lb.SelectedIndex = 0;
-            if (lb.SelectedIndex > MSBT_Data.MSBT_All_Data.Item.Count())
-                lb.SelectedIndex = 0;
+            if ((lb.SelectedIndex < 0)) lb.SelectedIndex = 0;
+            if (lb.SelectedIndex > MSBT_Data.MSBT_All_Data.Item.Count()) lb.SelectedIndex = 0;
             return lb.SelectedIndex;
         }
 
@@ -184,11 +182,10 @@ namespace MSBT_Editor
                 Tmp = MsbtAllData.Item[MsbtSelectIndex];
             }
 
-
             txtMsbtText.Text = MsbtAllData.Text[MsbtSelectIndex];
             txtReadOnlyMsbtText.Text = txtMsbtText.Text;
             txtAtr1SoundID.Text = Tmp.SoundID.ToString("X2");
-            txtAtr1SimpleCamID.Text = Tmp.SimpleCameraID.ToString("X2");
+            txtAtr1SimpleCameraID.Text = Tmp.SimpleCameraID.ToString("X2");
             txtAtr1DialogID.Text = Tmp.DialogID.ToString("X2");
             txtAtr1WindowID.Text = Tmp.WindowID.ToString("X2");
             txtAtr1EventCameraID.Text = Tmp.EventCameraID.ToString("X4");
@@ -226,13 +223,12 @@ namespace MSBT_Editor
             //ATR1セクションのテキストボックスの変更を
             //纏めるためのメソッドを作成中
             Console.WriteLine(((TextBox)sender).Name);
-            ATR1.ATR1_Change(txtAtr1SimpleCamID);
+            ATR1.ATR1_Change(txtAtr1SimpleCameraID);
         }
 
-        private void TxtAtr1SimpleCamID_TextChanged(object sender, EventArgs e)
+        private void TxtAtr1SimpleCameraID_TextChanged(object sender, EventArgs e)
         {
-
-            ATR1.ATR1_Change(txtAtr1SimpleCamID);
+            ATR1.ATR1_Change(txtAtr1SimpleCameraID);
         }
 
         private void TxtAtr1DialogID_TextChanged(object sender, EventArgs e)
@@ -264,7 +260,6 @@ namespace MSBT_Editor
         {
             if (lstListsInsideMsbt.Items.Count < 1) return;
             ATR1.SpecialTextList[lstListsInsideMsbt.SelectedIndex] = txtAtr1SpecialText.Text;
-
         }
 
         private void TxtLbl1TagIndex_TextChanged(object sender, EventArgs e)
@@ -279,12 +274,10 @@ namespace MSBT_Editor
 
         private void TxtMsbtText_TextChanged(object sender, EventArgs e)
         {
-
             if (lstListsInsideMsbt.Items.Count != 0)
             {
                 MSBT_Data.MSBT_All_Data.Text[lstListsInsideMsbt.SelectedIndex] = txtMsbtText.Text;
             }
-
         }
 
         //非常によくない複雑で長い処理。改善する必要があります。
@@ -1288,7 +1281,7 @@ namespace MSBT_Editor
         //ATR1セクションテキストボックスのキープレスイベント
         private void TxtAtr1SoundID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
-        private void TxtAtr1SimpleCamID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
+        private void TxtAtr1SimpleCameraID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
         private void TxtAtr1DialogID_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyHexChar(e, true);
 
@@ -1566,7 +1559,7 @@ namespace MSBT_Editor
                 txtReadOnlyMsbtText.Clear();
             }
             txtAtr1SoundID.Clear();
-            txtAtr1SimpleCamID.Clear();
+            txtAtr1SimpleCameraID.Clear();
             txtAtr1DialogID.Clear();
             txtAtr1WindowID.Clear();
             txtAtr1EventCameraID.Clear();

--- a/MSBT_Editor/Formsys/objects.cs
+++ b/MSBT_Editor/Formsys/objects.cs
@@ -57,7 +57,7 @@ namespace MSBT_Editor.Formsys
 
         //label 0～9
         protected static Label labeltxt01 = Form1.Form1Instance.lblAtr1SoundID;
-        protected static Label labeltxt02 = Form1.Form1Instance.lblAtr1SimpleCamID;
+        protected static Label labeltxt02 = Form1.Form1Instance.lblAtr1SimpleCameraID;
         protected static Label labeltxt03 = Form1.Form1Instance.lblAtr1DialogID;
         protected static Label labeltxt04 = Form1.Form1Instance.lblAtr1WindowID;
         protected static Label labeltxt05 = Form1.Form1Instance.lblAtr1EventCameraID;

--- a/MSBT_Editor/MSBTsys/MSBT_Header.cs
+++ b/MSBT_Editor/MSBTsys/MSBT_Header.cs
@@ -53,7 +53,8 @@ namespace MSBT_Editor.MSBTsys
             //終了処理
             fs.Close();
             br.Close();
-            for (var i = 0; i < MsbtListBox.Items.Count; i++)
+            int count = MsbtListBox.Items.Count;
+            for (var i = 0; i < count; i++)
             {
                 MsbtListBox.SelectedIndex = i;
                 Debugger.Unknowntagwriter(MsbtListBox.Text, true);

--- a/MSBT_Editor/Sectionsys/ATR1.cs
+++ b/MSBT_Editor/Sectionsys/ATR1.cs
@@ -138,11 +138,12 @@ namespace MSBT_Editor.Sectionsys
 
         private void SpecialTextReader(BinaryReader br, List<AttributeData> AttributeDataList, ref List<string> SpecialTextList)
         {
-            for (int j = 0; j < AttributeDataList.Count; j++)
+            int count = AttributeDataList.Count;
+            for (int j = 0; j < count; j++)
             {
 
                 string SpecialText;
-                if (AttributeDataList.Count - 1 == j)
+                if (count - 1 == j)
                 {
                     SpecialText = CS.Byte2Str_UTF16BE(br);
                 }
@@ -189,41 +190,37 @@ namespace MSBT_Editor.Sectionsys
                 sh = short.Parse(textbox.Text, System.Globalization.NumberStyles.HexNumber);
             }
 
-            
-
             ATR1.AttributeData element = MSBT_Data.MSBT_All_Data.Item[MsbtListBox.SelectedIndex];
 
             switch (textbox.Name)
             {
-                case "Atr1SoundID":
+                case "txtAtr1SoundID":
                     element.SoundID = bit;
                     break;
-                case "Atr1SimpleCamID":
+                case "txtAtr1SimpleCameraID":
                     element.SimpleCameraID = bit;
                     break;
-                case "Atr1DialogID":
+                case "txtAtr1DialogID":
                     element.DialogID = bit;
                     break;
-                case "Atr1WindowID":
+                case "txtAtr1WindowID":
                     element.WindowID = bit;
                     break;
-                case "Atr1EventCameraID":
+                case "txtAtr1EventCameraID":
                     element.EventCameraID = sh;
                     break;
-                case "Atr1MessageAreaID":
+                case "txtAtr1MessageAreaID":
                     element.MessageAreaID = bit;
                     break;
-                case "Atr1Unknown6":
+                case "txtAtr1Unknown6":
                     element.unknown6 = bit;
                     break;
             }
             MSBT_Data.MSBT_All_Data.Item[MsbtListBox.SelectedIndex] = element;
-
         }
 
         public void Write(BinaryWriter bw, FileStream fs)
         {
-
             var SectionSizePosition = fs.Position + 0x04;
             var BasePositionAddress = fs.Position + 0x10;
 
@@ -253,7 +250,8 @@ namespace MSBT_Editor.Sectionsys
 
             //特殊テキストの書き込み
             List<long> sptextoffset = new List<long>();
-            for (int j = 0; j < MsbtListBox.Items.Count; j++)
+            int msbtListBoxItemCount = MsbtListBox.Items.Count;
+            for (int j = 0; j < msbtListBoxItemCount; j++)
             {
                 MsbtListBox.SelectedIndex = j;
                 if (txtb11.Text == "")
@@ -272,8 +270,8 @@ namespace MSBT_Editor.Sectionsys
             //エントリーサイズが102の場合(星船など)
             //if (Entries == 102) bw.Write(CS.StringToBytes("0000"));
             var sptextend_pos = fs.Position;
-
-            for (int k = 0; k < nulloffsetpos.Count(); k++)
+            int nullOffsetPosCount = nulloffsetpos.Count();
+            for (int k = 0; k < nullOffsetPosCount; k++)
             {
                 fs.Seek(nulloffsetpos[k], SeekOrigin.Begin);
                 bw.Write(CS.StringToBytes(((int)sptextoffset[k]).ToString("X8")));

--- a/MSBT_Editor/Sectionsys/FEN1.cs
+++ b/MSBT_Editor/Sectionsys/FEN1.cs
@@ -537,7 +537,8 @@ namespace MSBT_Editor.Sectionsys
 
                 if (c.Index == 0)
                 {
-                    for (int k = 0; k < c.Value.Hash + 1; k++)
+                    uint valueHash = c.Value.Hash + 1;
+                    for (int k = 0; k < valueHash; k++)
                     {
                         if (c.Value.Hash != k) bw.Write(CS.StringToBytes((0).ToString("X8")));
                         else bw.Write(CS.StringToBytes(c.Value.tagflag.ToString("X8")));

--- a/MSBT_Editor/Sectionsys/FLW2.cs
+++ b/MSBT_Editor/Sectionsys/FLW2.cs
@@ -128,7 +128,7 @@ namespace MSBT_Editor.Sectionsys
             Debugger.MSBF_Text("");
 
             //データ読み取り
-            for (int i = 0; i< entry; i++) {
+            for (int i = 0; i < entry; i++) {
 
                 //読み取り
                 var type = CS.Byte2Short(br);
@@ -213,7 +213,8 @@ namespace MSBT_Editor.Sectionsys
                 bw.Write(CS.StringToBytes(flw2.Item[i].Unknown5.ToString("X4")));
             }
             Console.WriteLine(fs.Position.ToString("X"));
-            for (int j = 0; j < branchsize * 2; j++)
+            int size = branchsize * 2;
+            for (int j = 0; j < size; j++)
             {
                 bw.Write(CS.StringToBytes(flw2.Branch_No[j].ToString("X4")));
             }
@@ -397,7 +398,8 @@ namespace MSBT_Editor.Sectionsys
                         FLW2.branch_no.RemoveAt(item.Unknown5);
                         FLW2.branch_no.RemoveAt(item.Unknown5);
 
-                        for (int i = 0; i < FLW2.branch_list_no.Count(); i++)
+                        int count = FLW2.branch_list_no.Count();
+                        for (int i = 0; i < count; i++)
                         {
                             FLW2 flw2_1 = new FLW2();
                             FLW2.flw2_item item1 = flw2_1.Item[FLW2.branch_list_no[i]];

--- a/MSBT_Editor/Sectionsys/LBL1.cs
+++ b/MSBT_Editor/Sectionsys/LBL1.cs
@@ -131,7 +131,8 @@ namespace MSBT_Editor.Sectionsys
             var Tmp = MsbtListBoxIndexList;
             IOrderedEnumerable<int> MsbtListBoxIndexSorted = Tmp.OrderBy(x => x);
 
-            for (int l = 0; l < MsbtListBoxIndexList.Count; l++) 
+            int count = MsbtListBoxIndexList.Count;
+            for (int l = 0; l < count; l++) 
                 MsbtListBox.Items.Add(NameArray[l]);
 
             CS.Padding(br,fs.Position);
@@ -271,7 +272,8 @@ namespace MSBT_Editor.Sectionsys
         /// <param name="PositionLabelLastAddress"></param>
         private void DataSectionAllWriter(BinaryWriter bw , Hash_Data[] HashDataArray,List<long> PositionIndividualLabelTop,long PositionLabelLastAddress/*, ref int ActualDataCount*/) {
             var ActualDataCount = 0;
-            for (int i = 0; i < HashData.Count(); i++)
+            int count = HashData.Count();
+            for (int i = 0; i < count; i++)
             {
                 var NowHash = HashDataArray[i].Hash;
                 var SkipDataCount = HashDataArray.Where(a => a.Hash.Equals(NowHash)).Count();
@@ -290,7 +292,7 @@ namespace MSBT_Editor.Sectionsys
                 //同じハッシュ値の処理
                 if (SubtractNowFromBeforeHash == 0)
                 {
-                    if ((HashData.Count() - 1) != i)
+                    if ((count - 1) != i)
                     {
                         if (HashDataArray[i + 1].Hash - NowHash == 0)
                             continue;

--- a/MSBT_Editor/Sectionsys/TXT2.cs
+++ b/MSBT_Editor/Sectionsys/TXT2.cs
@@ -57,11 +57,12 @@ namespace MSBT_Editor.Sectionsys
             bw.Write(CS.StringToInt32_byte((MsbtListBox.Items.Count).ToString("X8")));
 
             var txt2_txt_offset_pos = fs.Position;
-            for (int i = 0; i < MsbtListBox.Items.Count; i++)
+            int count = MsbtListBox.Items.Count;
+            for (int i = 0; i < count; i++)
                 CS.Null_Writer_Int32(bw);
 
             List<int> txt2_offset_data = new List<int>();
-            for (int j = 0; j < MsbtListBox.Items.Count; j++)
+            for (int j = 0; j < count; j++)
             {
                 MsbtListBox.SelectedIndex = j;
                 txt2_offset_data.Add((int)(fs.Position - txt2_offset));
@@ -78,7 +79,7 @@ namespace MSBT_Editor.Sectionsys
             bw.Write(CS.StringToInt32_byte(((int)(txt2_txt_end - txt2_offset)).ToString("X8")));
 
             fs.Seek(txt2_txt_offset_pos, SeekOrigin.Begin);
-            for (int i = 0; i < MsbtListBox.Items.Count; i++)
+            for (int i = 0; i < count; i++)
                 bw.Write(CS.StringToInt32_byte(txt2_offset_data[i].ToString("X8")));
 
             fs.Seek(fileend_pos, SeekOrigin.Begin);


### PR DESCRIPTION
## 概要
-  テキストボックスによるATR1の引数変更を行ったときに、変更後の値が`MSBT_Data.MSBT_All_Data.Item[MsbtListBox.SelectedIndex]`に代入されない不具合を修正
- フォームのコントロール群の名前をリファクタリング
- for文の条件式中の計算式をfor文前に移動

## 不具合詳細
#24 で、ATR1の引数を格納するテキストボックスのコントロール名をリネームしたことに起因する不具合
- 変更後の値の代入は、ATR1の引数を格納するテキストボックスの値が変更された際に呼び出される`ATR1_Change`メソッドで行われるが、このメソッド中の代入処理にはテキストボックスのコントロール名によるswitch分岐が存在する
- switch分岐のcaseとして与えられている文字列が、"Atr1SoundID"のように、コントロールから名前を参照しない形となっていたため、コントロール名をリネームしてもcase文字列はリネームされなかった
- リネーム後のコントロール名は、switch文のcase文字列のいずれにも一致しないため、switch分岐中の変更後の値の代入処理が行われない

## 変更内容
`ATR1_Change`メソッド内のswitch文におけるcase文字列を、それぞれ現在のコントロール名に変更

## 備考
ATR1の引数のうち、SoundIDのみ`ATR1_Change`ではなく`ATR1TextBoxChange`を変更時に実行しています。
ATR1_Changeのswitch文のcaseにはSoundIDのものも存在するため、
他の引数と同様`ATR1_Change`を実行すればよいように思えます。
SoundIDのみ`ATR1_Change`ではなく`ATR1TextBoxChange`を実行していることには、何か理由があるのでしょうか。

`ATR1_Change`：Form1.csの229行目`TxtAtr1SimpleCameraID_TextChanged`メソッド内
`ATR1TextBoxChange`：Form1.csの212行目`TxtAtr1SoundID_TextChanged`メソッド内
`ATR1_Change`のswitch文：ATR1.csの177行目`ATR1_Change`メソッド内