### PR TITLE
テキストボックスによるFEN1とFLW2の引数変更が反映されない不具合を修正

### DIFF
--- a/MSBT_Editor/FileSys/Calculation_System.cs
+++ b/MSBT_Editor/FileSys/Calculation_System.cs
@@ -35,12 +35,50 @@ namespace MSBT_Editor.FileSys
             {
                 //MessageBox.Show((br.BaseStream.Position - readchers).ToString("X"), "error-------");
                 br.Close();
-                    string[] errorJP01 = { "深刻なエラーが発生しました\n\r[" + e.Message + "]\n\r" + "ErrorNo 1", "エラー" };
-                    string[] errorJP02 = { "「以前に他のMSBTエディタで編集していませんか？」\n\r", "ファイルフォーマット規則が一部破損しているので\n\r", "このエディタでは開くことが出来ません", "このエラーの原因で考えられること" };
-                    string[] errorJP03 = { "ゲームから吸い出した壊れていないデータを使用してください\n\r", "または、正しい方法でバイナリを修正する必要があります。\n\r", "このメッセージの後アプリケーションを強制終了します", "この問題への提案" };
-                    string[] errorEN01 = { "A serious error has occurred.\n\r[" + e.Message + "]\n\r" + "ErrorNo 1", "Error" };
-                    string[] errorEN02 = { "「Have you edited with a different 'MSBT editor' before?」\n\r", "The file formatting rules are partially broken,\n\r", "so this editor cannot open the file.", "Possible causes for this error." };
-                    string[] errorEN03 = { "Use the uncorrupted data sucked out of the game.\n\r", "Or you need to modify the binary in the right way.\n\r", "After this message, the application will be killed.", "Suggestions for this problem" };
+                    string[] errorJP01 =
+                    {
+                        "深刻なエラーが発生しました\r\n[" +
+                        e.Message +
+                        "]\r\n" +
+                        "ErrorNo 1",
+                        "エラー"
+                    };
+                    string[] errorJP02 =
+                    {
+                        "「以前に他のMSBTエディタで編集していませんか？」\r\n",
+                        "ファイルフォーマット規則が一部破損しているので\r\n",
+                        "このエディタでは開くことが出来ません",
+                        "このエラーの原因で考えられること"
+                    };
+                    string[] errorJP03 =
+                    {
+                        "ゲームから吸い出した壊れていないデータを使用してください\r\n",
+                        "または、正しい方法でバイナリを修正する必要があります。\r\n",
+                        "このメッセージの後アプリケーションを強制終了します",
+                        "この問題への提案"
+                    };
+                    string[] errorEN01 =
+                    {
+                        "A serious error has occurred.\r\n[" +
+                        e.Message +
+                        "]\r\n" +
+                        "ErrorNo 1",
+                        "Error"
+                    };
+                    string[] errorEN02 =
+                    {
+                        "「Have you edited with a different 'MSBT editor' before?」\r\n",
+                        "The file formatting rules are partially broken,\r\n",
+                        "so this editor cannot open the file.",
+                        "Possible causes for this error."
+                    };
+                    string[] errorEN03 =
+                    {
+                        "Use the uncorrupted data sucked out of the game.\r\n",
+                        "Or you need to modify the binary in the right way.\r\n",
+                        "After this message, the application will be killed.",
+                        "Suggestions for this problem"
+                    };
 
                     string[] error01;
                     string[] error02;
@@ -64,15 +102,17 @@ namespace MSBT_Editor.FileSys
                     MessageBox.Show(error03[0] + error03[1] + error03[2], error03[3], MessageBoxButtons.OK, MessageBoxIcon.Information);
                 
                     Environment.Exit(0);
-                
             }
-            
             return strs;
         }
 
-        public static void UTF16BE(string str, List<byte> bits) {
+        public static void UTF16BE(string str, List<byte> bits)
+        {
             var ret = Encoding.GetEncoding("unicodeFFFE").GetBytes(str);
-            foreach (byte bit in ret) bits.Add(bit);
+            foreach (byte bit in ret)
+            {
+                bits.Add(bit);
+            }
         }
 
         public static string Byte2JIS(BinaryReader br, FileStream fs)
@@ -81,19 +121,22 @@ namespace MSBT_Editor.FileSys
             byte bit1, bit2;
             byte bit3, bit4, bit5, bit6, bit7, bit8;
             bool checker = true;
-            while (checker) {
+            while (checker)
+            {
                 bit1 = br.ReadByte();
                 bit2 = br.ReadByte();
                 bit_list.Add(bit1);
                 bit_list.Add(bit2);
-                if (bit1 == 0x00 && bit2 == 0x0A) {
+                if (bit1 == 0x00 && bit2 == 0x0A)
+                {
                     UTF16BE("</br>" + EN.NewLine, bit_list);
                     continue;
                 }
 
 
 
-                if (((bit_list[bit_list.Count - 2] == 0x00) && (bit_list[bit_list.Count - 1]) == 0x0E)) {
+                if (((bit_list[bit_list.Count - 2] == 0x00) && (bit_list[bit_list.Count - 1]) == 0x0E))
+                {
                     bit_list.RemoveRange(bit_list.Count() - 1, 1);
                     bit_list.RemoveRange(bit_list.Count() - 1, 1);
                     bit3 = br.ReadByte();
@@ -103,8 +146,8 @@ namespace MSBT_Editor.FileSys
                     bit7 = br.ReadByte();
                     bit8 = br.ReadByte();
 
-
-                    switch (bit4) {
+                    switch (bit4)
+                    {
                         case 0x00:
                             Tag00(br, fs, bit_list, bit5, bit6, bit7, bit8);
                             continue;
@@ -132,24 +175,21 @@ namespace MSBT_Editor.FileSys
                         default:
                             break;
                     }
-
                     continue;
                 }
 
-                if ((bit_list[bit_list.Count - 2] == 0) && (bit_list[bit_list.Count - 1]) == 0) {
+                if ((bit_list[bit_list.Count - 2] == 0) && (bit_list[bit_list.Count - 1]) == 0)
+                {
                     bit_list.RemoveRange(bit_list.Count() - 1, 1);
                     bit_list.RemoveRange(bit_list.Count() - 1, 1);
                     UTF16BE("</End>", bit_list);
                     checker = false;
                 }
-
             }
             //Console.WriteLine(Encoding.GetEncoding("unicodeFFFE"/*1201*/).GetString(bit_list.ToArray()));
             //Debugger.Text("");
             return Encoding.GetEncoding("unicodeFFFE"/*1201*/).GetString(bit_list.ToArray());
-
         }
-
 
         public static bool Tag00(BinaryReader br, FileStream fs, List<byte> list, byte bit5, byte bit6, byte bit7, byte bit8)
         {
@@ -174,11 +214,15 @@ namespace MSBT_Editor.FileSys
             }
 
             UTF16BE(tagstrs, list);
-            if (tagstrs.Substring(1,7)== "Unknown") Debugger.Unknowntagwriter(tagstrs);
+            if (tagstrs.Substring(1, 7) == "Unknown")
+            {
+                Debugger.Unknowntagwriter(tagstrs);
+            }
             return true;
         }
 
-        public static string Tag_Colors(byte bit10) {
+        public static string Tag_Colors(byte bit10)
+        {
             var tagname = "";
             switch (bit10)
             {
@@ -209,20 +253,18 @@ namespace MSBT_Editor.FileSys
                 case 0xFF:
                     tagname = "</Color>";
                     break;
-
             }
             return tagname;
         }
 
-
-        public static bool Tag01(BinaryReader br, FileStream fs, List<byte> list, byte bit5, byte bit6, byte bit7, byte bit8) {
-
+        public static bool Tag01(BinaryReader br, FileStream fs, List<byte> list, byte bit5, byte bit6, byte bit7, byte bit8)
+        {
             string tagstrs = "<Unknown =\"Tag01\">";
             var bit9 = Bytes2Byte(br);
             var bit10 = Bytes2Byte(br);
-            switch (bit6) {
+            switch (bit6)
+            {
                 case 0x00:
-
                     if ((bit8 == 2))
                     {
                         var time = (bit9 << 8) + bit10;
@@ -231,48 +273,47 @@ namespace MSBT_Editor.FileSys
                     }
                     break;
                 case 0x01:
-
                     //10byte目が0x0Aではない場合の処理
                     tagstrs = "</NCenter>";
-
                     //新しいページ作成処理
-                    if ((bit8 == 0) && (bit9 == 0x00) && (bit10 == 0x0A)) {
+                    if ((bit8 == 0) && (bit9 == 0x00) && (bit10 == 0x0A))
+                    {
                         tagstrs = "</New_Page>" + EN.NewLine + EN.NewLine;
                         break;
                     }
-
                     //9,10bitを使用しない場合2bit分fsを戻す
                     fs.Position -= 2;
-
                     break;
                 case 0x02:
                     tagstrs = "</YCenter>";
-
                     //9,10bitを使用しない場合2bit分fsを戻す
                     fs.Position -= 2;
                     break;
                 case 0x03:
                     tagstrs = "</XCenter>";
-
                     //9,10bitを使用しない場合2bit分fsを戻す
                     fs.Position -= 2;
                     break;
             }
 
             UTF16BE(tagstrs, list);
-            if (tagstrs.Substring(1, 7) == "Unknown") Debugger.Unknowntagwriter(tagstrs);
+            if (tagstrs.Substring(1, 7) == "Unknown")
+            {
+                Debugger.Unknowntagwriter(tagstrs);
+            }
             return true;
         }
-
 
         public static bool Tag02(BinaryReader br, FileStream fs, List<byte> list, byte bit5, byte bit6, byte bit7, byte bit8)
         {
             var bit9 = Bytes2Byte(br);
             var bit10 = Bytes2Byte(br);
 
-            string tagstrs = "<SE=\""+ "000E00020000"+ bit7.ToString("X2")+ bit8.ToString("X2")+ bit9.ToString("X2")+ bit10.ToString("X2") + "\">";
-            var SEName = Byte2Str_UTF16BE(br , bit10);
-            tagstrs = "<SE=\""+ SEName +"\">";
+            string tagstrs
+                = "<SE=\"" + "000E00020000" + bit7.ToString("X2") + bit8.ToString("X2")
+                + bit9.ToString("X2") + bit10.ToString("X2") + "\">";
+            var SEName = Byte2Str_UTF16BE(br, bit10);
+            tagstrs = "<SE=\"" + SEName + "\">";
             //switch (bit6)
             //{
             //    case 0x00:
@@ -299,7 +340,9 @@ namespace MSBT_Editor.FileSys
             var bit9 = Bytes2Byte(br);
             var bit10 = Bytes2Byte(br);
 
-            var icon_num = "0003" + bit5.ToString("X2") + bit6.ToString("X2") + bit7.ToString("X2") + bit8.ToString("X2") + bit9.ToString("X2") + bit10.ToString("X2");
+            var icon_num
+                = "0003" + bit5.ToString("X2") + bit6.ToString("X2") + bit7.ToString("X2")
+                + bit8.ToString("X2") + bit9.ToString("X2") + bit10.ToString("X2");
             //Console.WriteLine(icon_num);
 
             string tagstrs = "<UserIcon=\"" + "000E" + icon_num + "\">";
@@ -521,17 +564,18 @@ namespace MSBT_Editor.FileSys
                 case "0003004000020045":
                     tagstrs = "<Icon=\"BronzeGrandStar\">";
                     break;
-
             }
 
             UTF16BE(tagstrs, list);
-            if (tagstrs.Substring(1, 7) == "Unknown") Debugger.Unknowntagwriter(tagstrs);
+            if (tagstrs.Substring(1, 7) == "Unknown")
+            {
+                Debugger.Unknowntagwriter(tagstrs);
+            }
             return true;
         }
 
         public static bool Tag04(BinaryReader br, FileStream fs, List<byte> list, byte bit5, byte bit6, byte bit7, byte bit8)
         {
-
             string tagstrs = "<Unknown=\"Tag04\">";
             switch (bit6)
             {
@@ -544,10 +588,12 @@ namespace MSBT_Editor.FileSys
                 case 0x02:
                     tagstrs = "<Size=\"Large\">";
                     break;
-
             }
             UTF16BE(tagstrs, list);
-            if (tagstrs.Substring(1, 7) == "Unknown") Debugger.Unknowntagwriter(tagstrs);
+            if (tagstrs.Substring(1, 7) == "Unknown")
+            {
+                Debugger.Unknowntagwriter(tagstrs);
+            }
             return true;
         }
 
@@ -559,12 +605,18 @@ namespace MSBT_Editor.FileSys
             switch (bit6)
             {
                 case 0x00:
-                    if (bit8 != 02) break;
+                    if (bit8 != 02)
+                    {
+                        break;
+                    }
                     tagstrs = "</PlayCharacter>";
                     break;
             }
             UTF16BE(tagstrs, list);
-            if (tagstrs.Substring(1, 7) == "Unknown") Debugger.Unknowntagwriter(tagstrs);
+            if (tagstrs.Substring(1, 7) == "Unknown")
+            {
+                Debugger.Unknowntagwriter(tagstrs);
+            }
             return true;
         }
 
@@ -582,24 +634,38 @@ namespace MSBT_Editor.FileSys
             switch (bit6)
             {
                 case 0x00:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</WorldNo>";
                     break;
                 case 0x01:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</ReferenceValue1>";
                     break;
                 case 0x02:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</ReferenceValue2>";
                     break;
                 case 0x03:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</ReferenceValue3>";
                     break;
                 case 0x04:
-                    if (bit8 != 08) break;
-                   
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     switch (lastbit)
                     {
                         case 00:
@@ -617,8 +683,12 @@ namespace MSBT_Editor.FileSys
                     }
                     break;
                 case 0x05:
-                    if (bit8 != 08) break;
-                    switch (lastbit) {
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
+                    switch (lastbit)
+                    {
                         case 00:
                             tagstrs = "</Hour>";
                             break;
@@ -632,17 +702,20 @@ namespace MSBT_Editor.FileSys
                             tagstrs = "</AfterTheDecimalPoint>";
                             break;
                     }
-                    
                     break;
             }
             UTF16BE(tagstrs, list);
-            if (tagstrs.Length > 8) {
+            if (tagstrs.Length > 8)
+            {
                 //Console.WriteLine("tagname   " + tagstrs.Substring(1, 7));
-                if (tagstrs.Substring(1, 7) == "Unknown" && tagstrs.Length > 8) Debugger.Unknowntagwriter(tagstrs);
+                if (tagstrs.Substring(1, 7) == "Unknown" && tagstrs.Length > 8)
+                {
+                    Debugger.Unknowntagwriter(tagstrs);
+                }
             }
-            
             return true;
         }
+
         public static bool Tag07(BinaryReader br, FileStream fs, List<byte> list, byte bit5, byte bit6, byte bit7, byte bit8)
         {
             Bytes2Byte(br);
@@ -657,11 +730,17 @@ namespace MSBT_Editor.FileSys
             switch (bit6)
             {
                 case 0x00:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</ResultGalaxyName>";
                     break;
                 case 0x01:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</ResultScenarioName>";
                     break;
                 case 0x02:
@@ -671,22 +750,30 @@ namespace MSBT_Editor.FileSys
                     tagstrs = "</UnusedTags07_03>";
                     break;
                 case 0x04:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</UserName>";
                     break;
                 case 0x05:
-                    if (bit8 != 08) break;
+                    if (bit8 != 08)
+                    {
+                        break;
+                    }
                     tagstrs = "</TotalPlayTime>";
                     break;
             }
             UTF16BE(tagstrs, list);
-            if (tagstrs.Substring(1, 7) == "Unknown") Debugger.Unknowntagwriter(tagstrs);
+            if (tagstrs.Substring(1, 7) == "Unknown")
+            {
+                Debugger.Unknowntagwriter(tagstrs);
+            }
             return true;
         }
 
-        
-
-        public static byte Bytes2Byte(BinaryReader br) {
+        public static byte Bytes2Byte(BinaryReader br)
+        {
             return br.ReadByte();
         }
 
@@ -700,11 +787,11 @@ namespace MSBT_Editor.FileSys
             return Int16.Parse(BitConverter.ToString(br.ReadBytes(readbyte), 0).Replace("-", "").PadLeft(readbyte, '0'), NumberStyles.HexNumber);
         }
 
-        
-
-        public static uint MSBT_Hash(string label, int num_slots) {
+        public static uint MSBT_Hash(string label, int num_slots)
+        {
             uint hash = 0;
-            foreach (char c in label) {
+            foreach (char c in label)
+            {
                 hash *= 0x492;
                 hash += c;
             }
@@ -762,10 +849,10 @@ namespace MSBT_Editor.FileSys
             return bs.ToArray();
         }
 
-        public static void StringToBytesWriter(BinaryWriter bw , string str) {
+        public static void StringToBytesWriter(BinaryWriter bw, string str)
+        {
             bw.Write(StringToBytes(str));
         }
-        
 
         public static byte[] StringToInt32_byte(string str)
         {
@@ -774,7 +861,6 @@ namespace MSBT_Editor.FileSys
             sh = Convert.ToInt32(str, 16);
             str2 = sh.ToString("X8");
             return StringToBytes(str2);
-
         }
 
         /// <summary>
@@ -782,31 +868,38 @@ namespace MSBT_Editor.FileSys
         /// <remarks>Null_Writer_Int32(進めたいバイナリライト、繰り返し回数(int型))</remarks>
         /// </summary>
         /// 
-        public static void Null_Writer_Int32(BinaryWriter bw , int write_rep_num = 1) {
-
+        public static void Null_Writer_Int32(BinaryWriter bw, int write_rep_num = 1)
+        {
             //0以上または、int型の最大値までしか選択できないようにする。
-            if (write_rep_num < 1) write_rep_num = 1;
-            if (Int32.MaxValue < write_rep_num) write_rep_num = Int32.MaxValue;
-
-            for(int i = 0; i<write_rep_num; i++)
-            bw.Write(BitConverter.GetBytes(0x00000000));
+            if (write_rep_num < 1)
+            {
+                write_rep_num = 1;
+            }
+            if (Int32.MaxValue < write_rep_num)
+            {
+                write_rep_num = Int32.MaxValue;
+            }
+            for (int i = 0; i < write_rep_num; i++)
+            {
+                bw.Write(BitConverter.GetBytes(0x00000000));
+            }
 
             //↓旧計算式
             //bw.Write(BitConverter.GetBytes(0x00000000));
         }
 
-        public static void UTF16BE_String_Writer(BinaryWriter bw , string str) {
+        public static void UTF16BE_String_Writer(BinaryWriter bw, string str)
+        {
             bw.Write(Encoding.GetEncoding("unicodeFFFE").GetBytes(str));
-            
         }
 
-        public static void String_Writer(BinaryWriter bw , string str , string EncodingName = "ASCII") {
+        public static void String_Writer(BinaryWriter bw, string str, string EncodingName = "ASCII")
+        {
             bw.Write(Encoding.GetEncoding(EncodingName).GetBytes(str));
         }
 
-        
-
-        public static string String2TagChecker(string str) {
+        public static string String2TagChecker(string str)
+        {
             var oldstr = str.Replace(EN.NewLine, "");
             oldstr = oldstr.Replace("\n", "");
             oldstr = oldstr.Replace("\r", "");
@@ -814,17 +907,16 @@ namespace MSBT_Editor.FileSys
             string[] oldstrarray = oldstr.Split(ch);
 
             int count = oldstrarray.Count();
-            for (int i = 0; i < count; i++) {
+            for (int i = 0; i < count; i++)
+            {
                 var roopstr = TagChecker(oldstrarray[i]);
                 oldstrarray[i] = roopstr;
             }
-            
             return string.Join("",oldstrarray);
         }
 
         public static string TagChecker(string str)
         {
-
             byte[] bits;
             switch (str)
             {
@@ -973,7 +1065,6 @@ namespace MSBT_Editor.FileSys
                 case "Icon=\"D-Pad Down\"":
                     bits = StringToBytes("000E000300450002004A");
                     break;
-
                 case "Icon=\"JoyStick\"":
                 case "Icon=\"Control Stick\"":
                     bits = StringToBytes("000E0003000F0002000F");
@@ -1014,7 +1105,6 @@ namespace MSBT_Editor.FileSys
                 case "Icon=\"Pull Star\"":
                     bits = StringToBytes("000E0003000900020009");
                     break;
-
                 case "Icon=\"Yoshi\"":
                     bits = StringToBytes("000E0003003400020039");
                     break;
@@ -1053,7 +1143,6 @@ namespace MSBT_Editor.FileSys
                 case "Icon=\"A Button\"":
                     bits = StringToBytes("000E0003000000020000");
                     break;
-
                 case "Icon=\"PurpleCoin\"":
                 case "Icon=\"Purple Coin\"":
                     bits = StringToBytes("000E0003001E0002001E");
@@ -1151,7 +1240,6 @@ namespace MSBT_Editor.FileSys
                 case "Icon=\"BronzeGrandStar\"":
                     bits = StringToBytes("000E0003004000020045");
                     break;
-
                 case "/World_No":
                 case "/WorldNo":
                     bits = StringToBytes("000E0006000000080000000000000000");
@@ -1177,7 +1265,6 @@ namespace MSBT_Editor.FileSys
                 case "/AfterTheDecimalPoint":
                     bits = StringToBytes("000E0006000500080000000000000003");
                     break;
-
                 case "/ResultGalaxyName":
                     bits = StringToBytes("000E0007000000080000000000000000");
                     break;
@@ -1219,7 +1306,8 @@ namespace MSBT_Editor.FileSys
                             var target = Int32.Parse(strs[3]);
                             var total = ((target) << 1) + ((rubi) << 1) ;
 
-                            switch (((target) << 1)) {
+                            switch (((target) << 1))
+                            {
                                 case 2:
                                     total += 2;
                                     break;
@@ -1236,7 +1324,6 @@ namespace MSBT_Editor.FileSys
                                     break;
                                 default:
                                     break;
-                            
                             }
                             
                             var hexnum = ((long)(total) << 32) + ((long)(target) << 17) + ((long)(rubi) << 1);
@@ -1245,7 +1332,8 @@ namespace MSBT_Editor.FileSys
                             break;
                         }
                     }
-                    if (str.Length > 5) {
+                    if (str.Length > 5)
+                    {
                         if (str.Substring(0, 6) == "/Timer")
                         {
                             var strs = str.Split('\"');
@@ -1255,8 +1343,10 @@ namespace MSBT_Editor.FileSys
                             break;
                         }
                     }
-                    if (str.Length > 8) {
-                        if (str.Substring(0,9) == "UserIcon=") {
+                    if (str.Length > 8)
+                    {
+                        if (str.Substring(0,9) == "UserIcon=")
+                        {
                             var strs = str.Split('\"');
                             bits = StringToBytes(strs[1]);
                             break;
@@ -1264,23 +1354,35 @@ namespace MSBT_Editor.FileSys
                     }
                     return str;
             }
-
             return Encoding.GetEncoding("unicodeFFFE"/*1201*/).GetString(bits);
         }
 
-        public static void TextBoxInsert(TextBox tb , string str) {
-            if (str == string.Empty) return;
+        public static void TextBoxInsert(TextBox tb, string str)
+        {
+            if (str == string.Empty)
+            {
+                return;
+            }
             tb.SelectedText = str;
         }
 
-        public static void TextBoxTagAdder(ListBox lb , TextBox tb , ComboBox cb , string[] strs) {
-            if (lb.Items.Count < 1) return;
-            if (cb.Items.Count == -1) return;
-            if (cb.SelectedIndex == -1) cb.SelectedIndex = 0;
+        public static void TextBoxTagAdder(ListBox lb, TextBox tb, ComboBox cb, string[] strs)
+        {
+            if (lb.Items.Count < 1)
+            {
+                return;
+            }
+            if (cb.Items.Count == -1)
+            {
+                return;
+            }
+            if (cb.SelectedIndex == -1)
+            {
+                cb.SelectedIndex = 0;
+            }
             int index = cb.SelectedIndex;
             string tag = strs[index];
             TextBoxInsert(tb, tag);
         }
-
     }
 }

--- a/MSBT_Editor/FileSys/Debugger.cs
+++ b/MSBT_Editor/FileSys/Debugger.cs
@@ -6,11 +6,13 @@ using System.Threading.Tasks;
 using System.Text.RegularExpressions;
 using MSBT_Editor.Formsys;
 using EN = System.Environment;
+
 namespace MSBT_Editor.FileSys
 {
-    public class Debugger:objects
+    public class Debugger : Objects
     {
-        public static void Text(string txt , bool txttop = false) {
+        public static void Text(string txt, bool txttop = false)
+        {
             if (txttop == true)
             {
                 msbtdebugtxt.Text = txt;
@@ -21,7 +23,8 @@ namespace MSBT_Editor.FileSys
             }
         }
 
-        public static void MSBF_Text(string txt, bool txttop = false , bool newline = true) {
+        public static void MSBF_Text(string txt, bool txttop = false, bool newline = true)
+        {
             if (txttop == true)
             {
                 txtb2.Text = txt;
@@ -32,14 +35,14 @@ namespace MSBT_Editor.FileSys
                 {
                     txtb2.AppendText(EN.NewLine + txt);
                 }
-                else {
-                    txtb2.AppendText( txt);
+                else
+                {
+                    txtb2.AppendText(txt);
                 }
-                
             }
         }
 
-        public static void HashTxt(string txt, bool txttop = false , bool newline = true)
+        public static void HashTxt(string txt, bool txttop = false, bool newline = true)
         {
             if (txttop == true)
             {
@@ -59,8 +62,8 @@ namespace MSBT_Editor.FileSys
             }
         }
 
-        public static void Unknowntagwriter(string str,bool dupeDelete = false) {
-
+        public static void Unknowntagwriter(string str,bool dupeDelete = false)
+        {
             //var spl = str.Split('_');
             //spl = spl.Replace("_End","");
 
@@ -70,11 +73,14 @@ namespace MSBT_Editor.FileSys
 
             //if (match == Match.Empty) return;
 
-            if (dupeDelete) {
-                
+            if (dupeDelete)
+            {
                 var find = unknowntag.Text.IndexOf(rem+"\r\n");
                 //Console.WriteLine(spl[0] + find);
-                if (find != -1) return;
+                if (find != -1)
+                {
+                    return;
+                }
             }
             unknowntag.AppendText(rem + EN.NewLine);
         }

--- a/MSBT_Editor/FileSys/Dialog.cs
+++ b/MSBT_Editor/FileSys/Dialog.cs
@@ -19,7 +19,7 @@ namespace MSBT_Editor.FileSys
     /// ダイアログクラス
     /// </summary>
     /// <remarks>ファイルを開いたり保存する</remarks>
-    public class Dialog : objects
+    public class Dialog : Objects
     {
         public static string Save_Path_Msbt = "None";
         public static string Save_Path_Msbf = "None";
@@ -71,32 +71,32 @@ namespace MSBT_Editor.FileSys
         {
             if (path == "None")
             {
-                MessageBox.Show(
+                MessageBox.Show
+                (
                     "ファイルを開くまたは保存先を指定してください",
                     "エラー",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error
-                    );
+                );
                 return true;
             }
             return false;
         }
 
-
-
         public static void Save(string filePath, int fileNum)
         {
-
             var hasPath = CheckSavePath(filePath);
             if (hasPath) return;
             FileSave(filePath, fileNum);
         }
 
-
         public static void Save(MSBF_Header MSBFH)
         {
             bool hasNotPath = CheckSavePath(Save_Path_Msbf);
-            if (hasNotPath) return;
+            if (hasNotPath)
+            {
+                return;
+            }
             MSBFH.Write(Save_Path_Msbf);
             SaveStatusPathString.Text = Save_Path_Msbf;
             SaveStatusPathString.ForeColor = Color.Green;
@@ -137,7 +137,6 @@ namespace MSBT_Editor.FileSys
                 SaveStatusPathString.Text = "保存がキャンセルされました。" + SaveMissTime();
                 SaveStatusPathString.ForeColor = Color.Red;
             }
-
         }
 
         public static void FileSave(string fileName, int fileNum)
@@ -145,11 +144,14 @@ namespace MSBT_Editor.FileSys
             switch (fileNum)
             {
                 case 1:
-                    SaveStatusPathString.Text = "Msbtを保存できませんでした" + SaveMissTime();
+                    SaveStatusPathString.Text = "MSBTを保存できませんでした" + SaveMissTime();
                     SaveStatusPathString.ForeColor = Color.Red;
                     
                     MSBT_Header msbth = new MSBT_Header();
-                    if (MSBT_Item_And_ListItem_Checker() == false) break;
+                    if (MSBT_Item_And_ListItem_Checker() == false)
+                    {
+                        break;
+                    }
                     msbth.Write(fileName);
                     Save_Path_Msbt = fileName;
                     SaveStatusPathString.Text = Save_Path_Msbt;
@@ -157,8 +159,11 @@ namespace MSBT_Editor.FileSys
                     break;
                 case 2:
                     SaveStatusPathString.ForeColor = Color.Red;
-                    SaveStatusPathString.Text = "Msbfを保存できませんでした。" + SaveMissTime();
-                    if (MSBF_Item_And_ListItem_Checker() == false) break;
+                    SaveStatusPathString.Text = "MSBFを保存できませんでした。" + SaveMissTime();
+                    if (MSBF_Item_And_ListItem_Checker() == false)
+                    {
+                        break;
+                    }
                     MSBF_Header msbfh = new MSBF_Header();
                     msbfh.Write(fileName);
                     Save_Path_Msbf = fileName;
@@ -169,7 +174,16 @@ namespace MSBT_Editor.FileSys
                     ArcSave(fileName);
                     break;
                 default:
-                    MessageBox.Show("このメッセージが表示されている場合\n\r" + "アプリ製作者のミスの可能性が高いので\n\r" + "至急このバージョンの制作者に連絡してください\n\r" + "ErrorName StaffMiss001 ", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show
+                    (
+                        "このメッセージが表示されている場合\r\n" +
+                        "アプリ製作者のミスの可能性が高いので\r\n" +
+                        "至急このバージョンの制作者に連絡してください\r\n" +
+                        "ErrorName StaffMiss001 ",
+                        "エラー",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error
+                    );
                     break;
             }
         }
@@ -178,7 +192,6 @@ namespace MSBT_Editor.FileSys
         {
             FLW2 flw2 = new FLW2();
             FEN1 fen1 = new FEN1();
-
 
             if (list2.Items.Count == 0 || (flw2.Item.Count == 0))
             {
@@ -205,7 +218,6 @@ namespace MSBT_Editor.FileSys
                 Debug.WriteLine("★　★_" + MsbtListCountZeroCheck + "_" + MsbtAllItemDefaultCheck + "_" + MsbtAllTextDefaultCheck);
                 return false;
             }
-
             return true;
         }
 
@@ -217,13 +229,10 @@ namespace MSBT_Editor.FileSys
 
             var MSBF_File_Path = Path.ChangeExtension(filePath, "msbf");
 
-
             if (HasFile == false)
             {
                 MessageBox.Show("ファイルが存在しません", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
-
-
 
             //拡張子の種類を判別
             switch (File_Extension.ToLower())
@@ -268,11 +277,16 @@ namespace MSBT_Editor.FileSys
                     var IsYaz0 = MagicChecker(filePath, "Yaz0");
                     if (IsYaz0 == true)
                     {
-                        MessageBox.Show(
+                        MessageBox.Show
+                        (
                             "Yaz0は未対応です\r\n" +
                             "RARCタイプのARCファイルのみ読み込めます\r\n" +
                             "Yaz0 is not supported.\r\n" +
-                            "Only RARC type ARC files can be read.", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            "Only RARC type ARC files can be read.",
+                            "エラー",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error
+                        );
                         return;
                     }
 
@@ -295,7 +309,6 @@ namespace MSBT_Editor.FileSys
                     ExternalFileExecutor efe = new ExternalFileExecutor();
                     efe.ARCToolExecutor(TempARCPath);
 
-
                     var TempParent = Directory.GetParent(TempARCPath).FullName;
                     var TempWorkingDirName = Path.GetFileNameWithoutExtension(TempARCPath);
                     string[] FilePathStrings = Directory.GetFiles(TempParent + @"\" + TempWorkingDirName, "*", SearchOption.AllDirectories);
@@ -308,7 +321,6 @@ namespace MSBT_Editor.FileSys
                         {
                             ArcInsideMsbtAndMsbfPath.Add(FilePath);
                             ARCListBox.Items.Add(Path.GetFileName(FilePath));
-
                         }
                     }
                     Temp_Path_Arc = TempARCPath;
@@ -323,23 +335,34 @@ namespace MSBT_Editor.FileSys
                     break;
 
                 default:
-                    MessageBox.Show("未対応のファイルです\r\n" + "MSBT,MSBF,ARC(RARC)ファイルのみ読み込めます", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show
+                    (
+                        "未対応のファイルです\r\n" +
+                        "MSBT,MSBF,ARC(RARC)ファイルのみ読み込めます",
+                        "エラー",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error
+                    );
                     return;
-
             }
-
-
-
-
         }
 
         public static void ArcSave(string newArcSavePath = "")
         {
             SaveStatusPathString.ForeColor = Color.Red;
             SaveStatusPathString.Text = "Arcを保存できませんでした。" + SaveMissTime();
-            if (ARCListBox.Items.Count < 1) return;
-            if (ArcInsideMsbtAndMsbfPath.Count < 1) return;
-            if (newArcSavePath != string.Empty) Save_Path_Arc = newArcSavePath;
+            if (ARCListBox.Items.Count < 1)
+            {
+                return;
+            }
+            if (ArcInsideMsbtAndMsbfPath.Count < 1)
+            {
+                return;
+            }
+            if (newArcSavePath != string.Empty)
+            {
+                Save_Path_Arc = newArcSavePath;
+            }
 
             var PathReplace = Temp_Path_Arc.Substring(0, Temp_Path_Arc.Length - 4);
             //Console.WriteLine(PathReplace);
@@ -353,7 +376,6 @@ namespace MSBT_Editor.FileSys
             //    var FileStrs = ARCTool.FileSys.DirectoryFileEdit.FileNameSort(PathReplace);/*Directory.GetFiles(PathReplace, "*", SearchOption.AllDirectories).OrderBy(sort => sort)*/;
             //    //if (DirStrs.Count() < 1) continue;
             //    //if (FileStrs.Count() < 1) continue;
-
 
             //    var arcfile = Path.GetFileName(PathReplace);
             //    var arcfolder = Path.GetDirectoryName(PathReplace);
@@ -395,7 +417,10 @@ namespace MSBT_Editor.FileSys
             var Magic = Calculation_System.Byte2Char(br);
             br.Close();
             fs.Close();
-            if (Magic == checkString) return true;
+            if (Magic == checkString)
+            {
+                return true;
+            }
             return false;
         }
     }

--- a/MSBT_Editor/FileSys/ExternalFileExecutor.cs
+++ b/MSBT_Editor/FileSys/ExternalFileExecutor.cs
@@ -10,7 +10,6 @@ using System.Windows.Forms;
 
 namespace MSBT_Editor.FileSys
 {
-    
     /// <summary>
     /// 外部の実行ファイルを実行するクラス
     /// </summary>
@@ -22,8 +21,8 @@ namespace MSBT_Editor.FileSys
         /// </summary>
         /// <param name="ARCToolExecutorSetDirectoryPath"></param>
         /// <param name="ARCToolExecutorSetPath"></param>
-        private static void ARCToolExeCutorCreator(ref string ARCToolExecutorSetDirectoryPath , ref string ARCToolExecutorSetPath) {
-
+        private static void ARCToolExeCutorCreator(ref string ARCToolExecutorSetDirectoryPath, ref string ARCToolExecutorSetPath)
+        {
             var AppExePath                  = Application.ExecutablePath;
             var AppDirectoryPath            = Path.GetDirectoryName(AppExePath);
             var ARCToolExeBinaryData           = Properties.Resources.ARCTool_ver0_1_5_0;
@@ -43,7 +42,9 @@ namespace MSBT_Editor.FileSys
             File.WriteAllBytes(ARCToolDepsJsonSetPath, ARCToolDepsJsonBinaryData);
             File.WriteAllBytes(ARCToolRuntimeJsonSetPath, ARCToolRuntimeJsonBinaryData);
         }
-        public void ARCToolExecutor(string filepath,bool isFolder = false) {
+
+        public void ARCToolExecutor(string filepath, bool isFolder = false)
+        {
             string ARCToolExecutorSetDirectoryPath = string.Empty;
             string ARCToolExecutorSetPath = string.Empty;
 
@@ -68,16 +69,17 @@ namespace MSBT_Editor.FileSys
             p.StartInfo = psi;
             p.Start();
             OutputCMD = p.StandardOutput.ReadToEnd();
-
             
             p.WaitForExit();
-            if (!p.HasExited) Console.WriteLine(p.StandardError.ReadToEnd());
+            if (!p.HasExited)
+            {
+                Console.WriteLine(p.StandardError.ReadToEnd());
+            }
             
             p.Close();
             p.Dispose();
 
             Console.WriteLine(OutputCMD);
         }
-
     }
 }

--- a/MSBT_Editor/Form1.Designer.cs
+++ b/MSBT_Editor/Form1.Designer.cs
@@ -2601,8 +2601,10 @@ namespace MSBT_Editor
             this.lblSaveSystemDiscription.Name = "lblSaveSystemDiscription";
             this.lblSaveSystemDiscription.Size = new System.Drawing.Size(235, 72);
             this.lblSaveSystemDiscription.TabIndex = 1;
-            this.lblSaveSystemDiscription.Text = "ARCファイルから開いたMSBTやMSBFの\r\n内容を変更した際は、上書き保存をしてください。\r\n上書き保存してからリストを選択し直さないと、\r\n変更が保存されま" +
-    "せん。\r\n全ての変更が終わったらARCを保存してください。\r\n※MSBT, MSBF以外は表示されません";
+            this.lblSaveSystemDiscription.Text
+                = "ARCファイルから開いたMSBTやMSBFの\r\n内容を変更した際は、上書き保存をしてください。\r\n"
+                + "上書き保存してからリストを選択し直さないと、\r\n変更が保存されません。\r\n"
+                + "全ての変更が終わったらARCを保存してください。\r\n※MSBT, MSBF以外は表示されません";
             // 
             // lstFilesInsideRarc
             // 

--- a/MSBT_Editor/Form1.cs
+++ b/MSBT_Editor/Form1.cs
@@ -15,7 +15,6 @@ using System.IO;
 using System.Globalization;
 using MSBT_Editor.MSBTsys;
 
-
 namespace MSBT_Editor
 {
     public partial class Form1 : Form
@@ -50,7 +49,6 @@ namespace MSBT_Editor
         private void Arc上書き保存ToolStripMenuItem_Click(object sender, EventArgs e) => Dialog.ArcSave();
         #endregion
 
-
         private void Form1_Load(object sender, EventArgs e)
         {
             Form1.Form1Instance = this;
@@ -66,22 +64,23 @@ namespace MSBT_Editor
             Language.Language_Check();
 
             chkShowTvwMsbfFlow.Checked = true;
+            //chkMsbAutoSave = true;
 
             //コマンドライン引数を配列で取得する
             string[] FilePathStrings = Environment.GetCommandLineArgs();
-            if (FilePathStrings.Length > 1) Dialog.FileCheck(FilePathStrings[1]);
-
-
+            if (FilePathStrings.Length > 1)
+            {
+                Dialog.FileCheck(FilePathStrings[1]);
+            }
         }
 
         private void VersionChecer()
         {
             System.Diagnostics.FileVersionInfo ver =
-        System.Diagnostics.FileVersionInfo.GetVersionInfo(
-        System.Reflection.Assembly.GetExecutingAssembly().Location);
+                System.Diagnostics.FileVersionInfo.GetVersionInfo(
+                System.Reflection.Assembly.GetExecutingAssembly().Location);
             lblCurrentVersion.Text = Path.GetFileNameWithoutExtension(ver.InternalName.ToString());
             lblCurrentVersion.Font = new Font(lblCurrentVersion.Font.FontFamily, 20);
-
         }
 
         #region デバッグと開発専用
@@ -95,7 +94,9 @@ namespace MSBT_Editor
                     == Language.FileReadStatusJP[0]) ||
                     (stbOpenedMsbtName.Text
                     == Language.FileReadStatusUS[0]))
+                {
                     return;
+                }
                 string appPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
                 string msbtname = Path.GetFileNameWithoutExtension(stbOpenedMsbtName.Text);
                 string textpath = Path.Combine(Path.GetDirectoryName(appPath), "Debug_" + msbtname + ".txt");
@@ -141,8 +142,14 @@ namespace MSBT_Editor
 
         public static int ListBoxIndex_NegativeThenSetIndexZero(ListBox lb)
         {
-            if ((lb.SelectedIndex < 0)) lb.SelectedIndex = 0;
-            if (lb.SelectedIndex > MSBT_Data.MSBT_All_Data.Item.Count()) lb.SelectedIndex = 0;
+            if ((lb.SelectedIndex < 0))
+            {
+                lb.SelectedIndex = 0;
+            }
+            if (lb.SelectedIndex > MSBT_Data.MSBT_All_Data.Item.Count())
+            {
+                lb.SelectedIndex = 0;
+            }
             return lb.SelectedIndex;
         }
 
@@ -166,7 +173,10 @@ namespace MSBT_Editor
             //    return;
             //}
 
-            if (MSBT_Data.MSBT_All_Data.Text.Count < 1) return;
+            if (MSBT_Data.MSBT_All_Data.Text.Count < 1)
+            {
+                return;
+            }
 
             var MsbtSelectIndex = ListBoxIndex_NegativeThenSetIndexZero(lstListsInsideMsbt);
             var MsbtAllData = MSBT_Data.MSBT_All_Data;
@@ -196,7 +206,10 @@ namespace MSBT_Editor
             txtSelectedMsbtListName.Text = lstListsInsideMsbt.Text;
             lblMsbtListSelectIndex.Text = "0x" + lstListsInsideMsbt.SelectedIndex.ToString("X");
 
-            if (EnableDebugMenu == false) return;
+            if (EnableDebugMenu == false)
+            {
+                return;
+            }
             //ハッシュスキップ数を表示
             var FindMsbtListTextIndexNum = LBL1.NameList.IndexOf(lstListsInsideMsbt.Text);
             if (-1 != FindMsbtListTextIndexNum)
@@ -211,7 +224,10 @@ namespace MSBT_Editor
 
         private void TxtAtr1SoundID_TextChanged(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             //Console.WriteLine(e.GetType().FullName);
             var Element = MSBT_Data.MSBT_All_Data.Item[lstListsInsideMsbt.SelectedIndex];
             Element.SoundID = ATR1.ATR1TextBoxChange(txtAtr1SoundID, Element.SoundID);
@@ -258,7 +274,10 @@ namespace MSBT_Editor
 
         private void TxtAtr1SpecialText_TextChanged(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             ATR1.SpecialTextList[lstListsInsideMsbt.SelectedIndex] = txtAtr1SpecialText.Text;
         }
 
@@ -286,7 +305,10 @@ namespace MSBT_Editor
         {
             if (lstListsInsideMsbt.Items.Count != 0)
             {
-                if (txtMsbtListName.Text == string.Empty) return;
+                if (txtMsbtListName.Text == string.Empty)
+                {
+                    return;
+                }
 
                 LBL1 lbl1 = new LBL1
                 {
@@ -310,7 +332,9 @@ namespace MSBT_Editor
 
                 //ハッシュ値がデフォルトの場合、新しいハッシュ値がハッシュリストの値を超える値を返す
                 if (HashMatchData.Hash == default)
+                {
                     HashMatchData = HashList.LastOrDefault(Old => Old.Hash > NewHash);
+                }
 
                 //ハッシュ値を基準に見つかったハッシュ構造体のリスト値に+1した値にリストを挿入する
                 HashMatchData.MsbtListBoxIndex++;
@@ -331,13 +355,15 @@ namespace MSBT_Editor
                 HashList = new List<LBL1.Hash_Data>(UnduplicatedData);
 
                 var FoundHashList = HashList.LastOrDefault(x => x.Hash == NewHash);
-                if (FoundHashList.Hash == default) FoundHashList = HashList.LastOrDefault(x => x.Hash > NewHash); ;
+                if (FoundHashList.Hash == default)
+                {
+                    FoundHashList = HashList.LastOrDefault(x => x.Hash > NewHash); ;
+                }
                 //ラベル情報を追加する
                 var lbl1_newindex = HashList.LastIndexOf(FoundHashList);
                 //lbl1_newindex ++;
                 foreach (var items in LBL1.NameList.Select((Value, Index) => (Value, Index)))
                 {
-
                     var hashdata = Calculation_System.MSBT_Hash(items.Value, lbl1.EntrySize);
 
                     lbl1.Item_1st.Add(new LBL1.LBL_1st_Item(LBL1.HashSkipList[items.Index], LBL1.NameList[items.Index], hashdata));
@@ -346,12 +372,14 @@ namespace MSBT_Editor
                 }
                 lbl1.Item_1st.Sort((a, b) => a.Hash.CompareTo(b.Hash));
                 var found1stitem = lbl1.Item_1st.LastOrDefault(x => x.Hash == NewHash);
-                if (found1stitem.Hash == default) found1stitem = lbl1.Item_1st.LastOrDefault(x => x.Hash > NewHash);
+                if (found1stitem.Hash == default)
+                {
+                    found1stitem = lbl1.Item_1st.LastOrDefault(x => x.Hash > NewHash);
+                }
 
                 var newindex = lbl1.Item_1st.LastIndexOf(found1stitem);
 
                 lbl1_newindex = /*testindex*/newindex;
-
 
                 if (lbl1_newindex != -1)
                 {
@@ -365,19 +393,26 @@ namespace MSBT_Editor
                 //BattanKing002_Flow000
                 //ScenarioName_RedBlueExGalaxy3
                 //MSBFファイルのフロータイプ1の対象MSBTの挿入以降の番号に+1する
-                if (lstListsInsideFlw2.Items.Count == 0 || lstListsInsideFen1.Items.Count == 0) return;
+                if (lstListsInsideFlw2.Items.Count == 0 || lstListsInsideFen1.Items.Count == 0)
+                {
+                    return;
+                }
                 FLW2 flw2 = new FLW2();
                 List<FLW2.flw2_item> copyitem = new List<FLW2.flw2_item>(flw2.Item);
                 foreach (var flw2item in copyitem.Select((Value, Index) => (Value, Index)))
                 {
-                    if (flw2item.Value.TypeCheck != 1) continue;
-                    if (flw2item.Value.Unknown3 < MsbtTextMatchData) continue;
+                    if (flw2item.Value.TypeCheck != 1)
+                    {
+                        continue;
+                    }
+                    if (flw2item.Value.Unknown3 < MsbtTextMatchData)
+                    {
+                        continue;
+                    }
                     FLW2.flw2_item newitem = flw2item.Value;
                     newitem.Unknown3++;
                     flw2.Item[flw2item.Index] = newitem;
                 }
-
-
             }
             else
             {
@@ -404,9 +439,13 @@ namespace MSBT_Editor
                     //リストボックス1とMSBTのデータに追加する
                     lstListsInsideMsbt.Items.Add(txtMsbtListName.Text);
                     if (Properties.Settings.Default.言語 == "EN")
+                    {
                         MSBT_Data.MSBT_All_Data.Text.Add("Default Text</End>");
+                    }
                     else
+                    {
                         MSBT_Data.MSBT_All_Data.Text.Add("テキスト</End>");
+                    }
                     MSBT_Data.MSBT_All_Data.Item.Add(new ATR1.AttributeData(0x1, 0x0, 0x0, 0x0, 0x0, 0xFF, 0xFF, 0x00));
                     MSBT_Data.Atr1SpecialText.Add("");
 
@@ -445,11 +484,9 @@ namespace MSBT_Editor
                     LBL1.NameList.RemoveAt(array_search);
                     LBL1.HashSkipList.RemoveAt(array_search);
                     LBL1.BeginEntryAdressList.RemoveAt(array_search);
-
-
                 }
 
-                //LBL1.list_name.RemoveRange(array_search , 1);
+                //LBL1.list_name.RemoveRange(array_search, 1);
                 //LBL1.unknown.RemoveRange(array_search, 1);
                 //LBL1.unknownpos.RemoveRange(array_search, 1);
                 var listselect = lstListsInsideMsbt.SelectedIndex;
@@ -506,7 +543,6 @@ namespace MSBT_Editor
             FontSizeTag.ToMsbtTextBoxInsert();
         }
 
-
         private void BtnInsertCenterTag_Click(object sender, EventArgs e)
         {
             var CenterTag = new MSBT_TagData.TagInsertModified(new MSBT_TagData.CenterTag())
@@ -520,8 +556,14 @@ namespace MSBT_Editor
 
         private void BtnInsertRubiTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
-            if (txtRubiTagRubiCount.Text == "" || txtRubiTagKanjiCount.Text == "") return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
+            if (txtRubiTagRubiCount.Text == "" || txtRubiTagKanjiCount.Text == "")
+            {
+                return;
+            }
             string furigana = txtRubiTagRubiCount.Text;
             string kanji = txtRubiTagKanjiCount.Text;
             string tag = "<Rubi=\"" + furigana + "\" Target=\"" + kanji + "\">";
@@ -532,11 +574,16 @@ namespace MSBT_Editor
         private void TxtRubiTagKanjiCount_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyDecChar(e);
         private void TxtTimerTagDelayTime_KeyPress(object sender, KeyPressEventArgs e) => KeyPressEventSupport.OnlyDecChar(e);
 
-
         private void BtnInsertTimerTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
-            if (txtTimerTagDelayTime.Text == "") return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
+            if (txtTimerTagDelayTime.Text == "")
+            {
+                return;
+            }
             string time = txtTimerTagDelayTime.Text;
             string tag = "</Timer=\"" + time + "\">";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
@@ -544,28 +591,40 @@ namespace MSBT_Editor
 
         private void BtnInsertPlayerCharacterTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</PlayCharacter>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertVariableInt3DigitsTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</ReferenceValue1>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertResultGalaxyNameTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</ResultGalaxyName>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertResultScenarioNameTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</ResultScenarioName>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
@@ -574,7 +633,8 @@ namespace MSBT_Editor
         {
             if (Properties.Settings.Default.言語 == "EN")
             {//all icons in one combo
-                string[] IconTag = {
+                string[] IconTag =
+                {
                     "<Icon=\"AButton\">",
                     "<Icon=\"BButton\">",
                     "<Icon=\"CButton\">",
@@ -645,75 +705,126 @@ namespace MSBT_Editor
                     "<Icon=\"DPadDown\">",
                     "<Icon=\"Columa\">",
                     "<Icon=\"Kinopio\">",
-                    "<Icon=\"BronzeComet\">", };
-
+                    "<Icon=\"BronzeComet\">",
+                };
                 Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbCharacterIconTag, IconTag);
             }
             else
             {
-                string[] IconTag = { "<Icon=\"Peach\">", "<Icon=\"Koopa\">", "<Icon=\"Kinopio\">", "<Icon=\"Mario\">", "<Icon=\"Mario2\">", "<Icon=\"Tico\">", "<Icon=\"Yoshi\">", "<Icon=\"HarapekoTico\">", "<Icon=\"Luigi\">", "<Icon=\"MasterTico\">", "<Icon=\"Columa\">", "<Icon=\"Begoman\">", "<Icon=\"Kuribo\">", "<Icon=\"Star Bunny\">" };
+                string[] IconTag =
+                {
+                    "<Icon=\"Peach\">", "<Icon=\"Koopa\">", "<Icon=\"Kinopio\">", "<Icon=\"Mario\">",
+                    "<Icon=\"Mario2\">", "<Icon=\"Tico\">", "<Icon=\"Yoshi\">", "<Icon=\"HarapekoTico\">",
+                    "<Icon=\"Luigi\">", "<Icon=\"MasterTico\">", "<Icon=\"Columa\">", "<Icon=\"Begoman\">",
+                    "<Icon=\"Kuribo\">", "<Icon=\"Star Bunny\">"
+                };
                 Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbCharacterIconTag, IconTag);
             }
         }
 
         private void BtnInsertObjectIconTag_Click(object sender, EventArgs e)
         {
-            string[] IconTag = { "<Icon=\"CometMedal\">", "<Icon=\"Coins\">", "<Icon=\"Starbit\">", "<Icon=\"StarPiece\">", "<Icon=\"PurpleStarbit\">", "<Icon=\"SilverStar\">", "<Icon=\"Star\">", "<Icon=\"GrandStar\">", "<Icon=\"BronzeStar\">", "<Icon=\"Coin\">", "<Icon=\"PurpleCoin\">", "<Icon=\"1UPMushroom\">", "<Icon=\"LifeUpMushroom\">", "<Icon=\"BlueStar\">", "<Icon=\"StarRing\">", "<Icon=\"Flower\">", "<Icon=\"Coconut\">", "<Icon=\"BlueChip\">", "<Icon=\"BlueFruit\">", "<Icon=\"CheckPointFlag\">", "<Icon=\"GrandBronzeStar\">" };
+            string[] IconTag =
+            {
+                "<Icon=\"CometMedal\">", "<Icon=\"Coins\">", "<Icon=\"Starbit\">", "<Icon=\"StarPiece\">",
+                "<Icon=\"PurpleStarbit\">", "<Icon=\"SilverStar\">", "<Icon=\"Star\">", "<Icon=\"GrandStar\">",
+                "<Icon=\"BronzeStar\">", "<Icon=\"Coin\">", "<Icon=\"PurpleCoin\">", "<Icon=\"1UPMushroom\">",
+                "<Icon=\"LifeUpMushroom\">", "<Icon=\"BlueStar\">", "<Icon=\"StarRing\">", "<Icon=\"Flower\">",
+                "<Icon=\"Coconut\">", "<Icon=\"BlueChip\">", "<Icon=\"BlueFruit\">", "<Icon=\"CheckPointFlag\">",
+                "<Icon=\"GrandBronzeStar\">"
+            };
             Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbObjectIconTag, IconTag);
         }
 
         private void BtnInsertOtherIconTag_Click(object sender, EventArgs e)
         {
-            string[] IconTag = { "<Icon=\"Pointer\">", "<Icon=\"PointerYellow\">", "<Icon=\"PointerHand\">", "<Icon=\"WiiMote\">", "<Icon=\"AButton\">", "<Icon=\"BButton\">", "<Icon=\"CButton\">", "<Icon=\"ZButton\">", "<Icon=\"DPad\">", "<Icon=\"DPadDown\">", "<Icon=\"DPadUp\">", "<Icon=\"JoyStick\">", "<Icon=\"Nunchuck\">", "<Icon=\"Aim\">", "<Icon=\"MButton\">", "<Icon=\"PButton\">", "<Icon=\"XIcon\">", "<Icon=\"GreenComet\">", "<Icon=\"SilverCrown\">", "<Icon=\"SilverCrownwJewel\">", "<Icon=\"GoldCrown\">", "<Icon=\"Letter\">", "<Icon=\"ArrowDown\">", "<Icon=\"StopWatch\">", "<Icon=\"1Button\">", "<Icon=\"2Button\">", "<Icon=\"HomeButton\">", "<Icon=\"PointerGrip\">", "<Icon=\"PointerNonGrip\">", "<Icon=\"QuestionMark\">", "<Icon=\"YellowComet\">", "<Icon=\"GreenQuestionMark\">", "<Icon=\"EmptyStar\">", "<Icon=\"EmptyCometMedal\">", "<Icon=\"EmptyStarComet\">", "<Icon=\"HiddenStar\">", "<Icon=\"BronzeComet\">" };
+            string[] IconTag =
+            {
+                "<Icon=\"Pointer\">", "<Icon=\"PointerYellow\">", "<Icon=\"PointerHand\">", "<Icon=\"WiiMote\">",
+                "<Icon=\"AButton\">", "<Icon=\"BButton\">", "<Icon=\"CButton\">", "<Icon=\"ZButton\">",
+                "<Icon=\"DPad\">", "<Icon=\"DPadDown\">", "<Icon=\"DPadUp\">", "<Icon=\"JoyStick\">",
+                "<Icon=\"Nunchuck\">", "<Icon=\"Aim\">", "<Icon=\"MButton\">", "<Icon=\"PButton\">",
+                "<Icon=\"XIcon\">", "<Icon=\"GreenComet\">", "<Icon=\"SilverCrown\">",
+                "<Icon=\"SilverCrownwJewel\">", "<Icon=\"GoldCrown\">", "<Icon=\"Letter\">",
+                "<Icon=\"ArrowDown\">", "<Icon=\"StopWatch\">", "<Icon=\"1Button\">", "<Icon=\"2Button\">",
+                "<Icon=\"HomeButton\">", "<Icon=\"PointerGrip\">", "<Icon=\"PointerNonGrip\">",
+                "<Icon=\"QuestionMark\">", "<Icon=\"YellowComet\">", "<Icon=\"GreenQuestionMark\">",
+                "<Icon=\"EmptyStar\">", "<Icon=\"EmptyCometMedal\">", "<Icon=\"EmptyStarComet\">",
+                "<Icon=\"HiddenStar\">", "<Icon=\"BronzeComet\">"
+            };
             Calculation_System.TextBoxTagAdder(lstListsInsideMsbt, txtMsbtText, cmbOtherIconTag, IconTag);
         }
 
         private void BtnInsertVariableInt4DigitsTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</ReferenceValue2>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertVariableInt5DigitsTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</ReferenceValue3>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertHourTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</Hour>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertMinuteTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</Minutes>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertSecondTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</Seconds>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertNumbersBelowDecimalPointTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</AfterTheDecimalPoint>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnReleaseDebugTextFile_Click(object sender, EventArgs e)
         {
-            if (stbOpenedMsbtName.Text == " ") return;
-            if (txtFlw2DebugHex.Text == "") return;
+            if (stbOpenedMsbtName.Text == " ")
+            {
+                return;
+            }
+            if (txtFlw2DebugHex.Text == "")
+            {
+                return;
+            }
             string appPath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             string msbtname = Path.GetFileNameWithoutExtension(stbOpenedMsbtName.Text);
             string textpath = Path.Combine(Path.GetDirectoryName(appPath), msbtname + ".txt");
@@ -727,9 +838,15 @@ namespace MSBT_Editor
             this.txtFlw2BranchTrue.TextChanged -= new EventHandler(this.TxtFlw2BranchTrue_TextChanged);
             this.txtFlw2BranchFalse.TextChanged -= new EventHandler(this.TxtFlw2BranchFalse_TextChanged);
 
-            if (lstListsInsideFlw2.Items.Count == 0) return;
+            if (lstListsInsideFlw2.Items.Count == 0)
+            {
+                return;
+            }
             var index = lstListsInsideFlw2.SelectedIndex;
-            if (index == -1) index = 0;
+            if (index == -1)
+            {
+                index = 0;
+            }
             FLW2 flw2 = new FLW2();
             //Console.WriteLine(index);
             txtFlw2FlowType.Text = flw2.Item[index].TypeCheck.ToString("X4");
@@ -746,7 +863,10 @@ namespace MSBT_Editor
                     lblFlw2Arg2.Text = "MSBTテキストlist番号";
                     lblFlw2Arg3.Text = "FLW2オフセット";
                     lblFlw2Arg4.Text = "不明5";
-                    if (Properties.Settings.Default.言語 == "日本語") break;
+                    if (Properties.Settings.Default.言語 == "日本語")
+                    {
+                        break;
+                    }
                     lblFlw2Arg1.Text = "Group number";
                     lblFlw2Arg2.Text = "MSBT Entry";
                     lblFlw2Arg3.Text = "Next Flow";
@@ -757,7 +877,10 @@ namespace MSBT_Editor
                     lblFlw2Arg2.Text = "不明3";
                     lblFlw2Arg3.Text = "不明4";
                     lblFlw2Arg4.Text = "分岐先オフセット";
-                    if (Properties.Settings.Default.言語 == "日本語") break;
+                    if (Properties.Settings.Default.言語 == "日本語")
+                    {
+                        break;
+                    }
                     lblFlw2Arg1.Text = "Always 0002";
                     lblFlw2Arg2.Text = "Condition ID";
                     lblFlw2Arg3.Text = "Unknown4";
@@ -768,7 +891,10 @@ namespace MSBT_Editor
                     lblFlw2Arg2.Text = "不明3";
                     lblFlw2Arg3.Text = "不明4";
                     lblFlw2Arg4.Text = "不明5";
-                    if (Properties.Settings.Default.言語 == "日本語") break;
+                    if (Properties.Settings.Default.言語 == "日本語")
+                    {
+                        break;
+                    }
                     lblFlw2Arg1.Text = "Next Flow ID";
                     lblFlw2Arg2.Text = "Unknown3";
                     lblFlw2Arg3.Text = "Unknown4";
@@ -779,7 +905,10 @@ namespace MSBT_Editor
                     lblFlw2Arg2.Text = "FLWオフセット";
                     lblFlw2Arg3.Text = "不明4";
                     lblFlw2Arg4.Text = "不明5";
-                    if (Properties.Settings.Default.言語 == "日本語") break;
+                    if (Properties.Settings.Default.言語 == "日本語")
+                    {
+                        break;
+                    }
                     lblFlw2Arg1.Text = "Event ID";
                     lblFlw2Arg2.Text = "Next Flow";
                     lblFlw2Arg3.Text = "Unknown4";
@@ -790,13 +919,15 @@ namespace MSBT_Editor
                     lblFlw2Arg2.Text = "不明3";
                     lblFlw2Arg3.Text = "不明4";
                     lblFlw2Arg4.Text = "不明5";
-                    if (Properties.Settings.Default.言語 == "日本語") break;
+                    if (Properties.Settings.Default.言語 == "日本語")
+                    {
+                        break;
+                    }
                     lblFlw2Arg1.Text = "Unknown2";
                     lblFlw2Arg2.Text = "Unknown3";
                     lblFlw2Arg3.Text = "Unknown4";
                     lblFlw2Arg4.Text = "Unknown5";
                     break;
-
             }
 
             var blnc = flw2.Branch_List_No.Count * 2;
@@ -811,7 +942,6 @@ namespace MSBT_Editor
             }
             if (-1 == flw2.Branch_List_No.IndexOf(index))
             {
-
                 txtFlw2BranchTrue.Text = "";
                 txtFlw2BranchFalse.Text = "";
                 lblFlw2ListSelectIndex.Text = "0x" + lstListsInsideFlw2.SelectedIndex.ToString("X");
@@ -820,7 +950,13 @@ namespace MSBT_Editor
                 return;
             }
             textBox27.AppendText(Environment.NewLine + "selectlist");
-            textBox27.AppendText(Environment.NewLine + flw2.Branch_No[flw2.Branch_List_No.IndexOf(index)].ToString("X4") + "___" + flw2.Branch_List_No.IndexOf(index));
+            textBox27.AppendText
+            (
+                Environment.NewLine +
+                flw2.Branch_No[flw2.Branch_List_No.IndexOf(index)].ToString("X4") +
+                "___" +
+                flw2.Branch_List_No.IndexOf(index)
+            );
 
             txtFlw2BranchTrue.Text = flw2.Branch_No[(flw2.Branch_List_No.IndexOf(index) * 2)].ToString("X4");
             txtFlw2BranchFalse.Text = flw2.Branch_No[(flw2.Branch_List_No.IndexOf(index) * 2) + 1].ToString("X4");
@@ -883,9 +1019,11 @@ namespace MSBT_Editor
             if (EnableDebugMenu == true)
             {
                 MultipleFileRead(fileName, out bool readFiles);
-                if (readFiles == true) return;
+                if (readFiles == true)
+                {
+                    return;
+                }
             }
-
 
             if (filecount == 2)
             {
@@ -894,7 +1032,15 @@ namespace MSBT_Editor
 
                 if (path1 == path2)
                 {
-                    MessageBox.Show("2つファイルを読み込む場合" + "\n\r" + "MSBTとMSBFの組み合わせのみです", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show
+                    (
+                        "2つファイルを読み込む場合" +
+                        "\r\n" +
+                        "MSBTとMSBFの組み合わせのみです",
+                        "エラー",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error
+                    );
                     return;
                 }
             }
@@ -909,14 +1055,23 @@ namespace MSBT_Editor
                     Dialog.FileCheck(fileName[1]);
                     break;
                 default:
-                    MessageBox.Show("3つ以上のファイルはドロップできません", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show
+                    (
+                        "3つ以上のファイルはドロップできません",
+                        "エラー",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error
+                    );
                     break;
             }
         }
 
         private void Form1_DragEnter(object sender, DragEventArgs e)
         {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop)) e.Effect = DragDropEffects.Copy;
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                e.Effect = DragDropEffects.Copy;
+            }
             else e.Effect = DragDropEffects.None;
         }
 
@@ -935,9 +1090,15 @@ namespace MSBT_Editor
             this.txtFen1Arg0.TextChanged -= new EventHandler(this.TxtFen1Arg0_TextChanged);
             this.txtFen1StartIndex.TextChanged -= new EventHandler(this.TxtFen1StartIndex_TextChanged);
 
-            if (lstListsInsideFen1.Items.Count == 0) return;
+            if (lstListsInsideFen1.Items.Count == 0)
+            {
+                return;
+            }
             var index = lstListsInsideFen1.SelectedIndex;
-            if (index == -1) index = 0;
+            if (index == -1)
+            {
+                index = 0;
+            }
 
             FEN1 fen1 = new FEN1();
             var hashes = Calculation_System.MSBT_Hash(fen1.Item2[index].tagname, 0x3B);
@@ -946,12 +1107,14 @@ namespace MSBT_Editor
             txtFen1Arg0.Text = fen1.Hashes[index].tagflag.ToString("X8");
             txtFen1StartIndex.Text = fen1.Item2[index].tagnum.ToString("X8");
 
-            if (lstListsInsideFlw2.Items.Count > fen1.Item2[index].tagnum) lstListsInsideFlw2.SelectedIndex = fen1.Item2[index].tagnum;
+            if (lstListsInsideFlw2.Items.Count > fen1.Item2[index].tagnum)
+            {
+                lstListsInsideFlw2.SelectedIndex = fen1.Item2[index].tagnum;
+            }
 
             lblFen1ListSelectIndex.Text = "0x" + lstListsInsideFen1.SelectedIndex.ToString("X");
             this.txtFen1Arg0.TextChanged += new EventHandler(this.TxtFen1Arg0_TextChanged);
             this.txtFen1StartIndex.TextChanged += new EventHandler(this.TxtFen1StartIndex_TextChanged);
-
         }
 
         private void BtnAddFlw2List_Click(object sender, EventArgs e)
@@ -1010,7 +1173,6 @@ namespace MSBT_Editor
                     fen1.Hashes.Add(new FEN1.Hash_And_Unknown(1, hash));
                     //treeView1.Nodes.Add(textBox31.Text);
 
-
                     //if (listBox2.Items.Count != 0)
                     //{
                     //    listBox2.Items.Add(Language.FLW2_List_Language(4));
@@ -1036,7 +1198,6 @@ namespace MSBT_Editor
                     fen1.Item1 = new List<FEN1.Element>();
                     fen1.Item2 = new List<FEN1.ElementTag>();
                     fen1.Hashes = new List<FEN1.Hash_And_Unknown>();
-
 
                     lstListsInsideFen1.Items.Add(txtFen1ListName.Text);
                     fen1.Item1.Add(new FEN1.Element(1, 0));
@@ -1076,10 +1237,7 @@ namespace MSBT_Editor
                 Console.WriteLine(fen1.Item2.Count());
                 Console.WriteLine(fen1.Hashes.Count());
 
-
-
                 var listselect = lstListsInsideFen1.SelectedIndex;
-
 
                 //fen1.Item1.RemoveAt(listselect);
                 fen1.Item2.RemoveAt(listselect);
@@ -1103,7 +1261,6 @@ namespace MSBT_Editor
                     Properties.Settings.Default.言語 = "日本語";
                     break;
             }
-
             Properties.Settings.Default.Save();
             Formsys.Language.Language_Check();
         }
@@ -1123,8 +1280,14 @@ namespace MSBT_Editor
         private void TvwMsbfFlow_AfterSelect(object sender, TreeViewEventArgs e)
         {
             FLW2 flw2 = new FLW2();
-            if (tvwMsbfFlow.Nodes.Count == 0) return;
-            if (tvwMsbfFlow.SelectedNode.Tag == default) return;
+            if (tvwMsbfFlow.Nodes.Count == 0)
+            {
+                return;
+            }
+            if (tvwMsbfFlow.SelectedNode.Tag == default)
+            {
+                return;
+            }
 
             //var oldindex = MsbfTreeView.SelectedNode;
             var rootnode = Form1.TreeViewParentFinder(tvwMsbfFlow);
@@ -1136,7 +1299,6 @@ namespace MSBT_Editor
                 lstListsInsideFen1.SelectedIndex = rootnodelistbox3find;
             }
 
-
             var roottag = (FLW2.flw2_item)rootnode.Tag;
             var a = (FLW2.flw2_item)tvwMsbfFlow.SelectedNode.Tag;
             var find = flw2.Item.IndexOf(a);
@@ -1144,33 +1306,60 @@ namespace MSBT_Editor
             {
                 case 1:
                     //Console.WriteLine("メッセージ");
-                    if (lstListsInsideMsbt.Items.Count == 0) break;
-                    if (lstListsInsideMsbt.Items.Count > a.Unknown3) lstListsInsideMsbt.SelectedIndex = a.Unknown3;
-                    if (lstListsInsideFlw2.Items.Count == 0) break;
-                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
+                    if (lstListsInsideMsbt.Items.Count == 0)
+                    {
+                        break;
+                    }
+                    if (lstListsInsideMsbt.Items.Count > a.Unknown3)
+                    {
+                        lstListsInsideMsbt.SelectedIndex = a.Unknown3;
+                    }
+                    if (lstListsInsideFlw2.Items.Count == 0)
+                    {
+                        break;
+                    }
+                    if (lstListsInsideFlw2.Items.Count > find)
+                    {
+                        lstListsInsideFlw2.SelectedIndex = find;
+                    }
                     break;
                 case 2:
                     //Console.WriteLine("分岐");
-                    if (lstListsInsideFlw2.Items.Count == 0) break;
-                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
+                    if (lstListsInsideFlw2.Items.Count == 0)
+                    {
+                        break;
+                    }
+                    if (lstListsInsideFlw2.Items.Count > find)
+                    {
+                        lstListsInsideFlw2.SelectedIndex = find;
+                    }
                     break;
                 case 3:
                     //Console.WriteLine("イベント");
-                    if (lstListsInsideFlw2.Items.Count == 0) break;
-                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
+                    if (lstListsInsideFlw2.Items.Count == 0)
+                    {
+                        break;
+                    }
+                    if (lstListsInsideFlw2.Items.Count > find)
+                    {
+                        lstListsInsideFlw2.SelectedIndex = find;
+                    }
                     break;
                 case 4:
                     //Console.WriteLine("エントリーポイント");
-                    if (lstListsInsideFlw2.Items.Count == 0) break;
-                    if (lstListsInsideFlw2.Items.Count > find) lstListsInsideFlw2.SelectedIndex = find;
+                    if (lstListsInsideFlw2.Items.Count == 0)
+                    {
+                        break;
+                    }
+                    if (lstListsInsideFlw2.Items.Count > find)
+                    {
+                        lstListsInsideFlw2.SelectedIndex = find;
+                    }
                     break;
                 default:
-
                     break;
             }
-
             //if (a.TypeCheck == 4) Console.WriteLine("せれくとつりー");
-
         }
 
         private void BtnCalculateHash_Click(object sender, EventArgs e)
@@ -1183,28 +1372,40 @@ namespace MSBT_Editor
 
         private void BtnInsertWorldNoTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</WorldNo>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertScoreTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</Score01>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertUserNameTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</UserName>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
 
         private void BtnInsertTotalPlayTimeTag_Click(object sender, EventArgs e)
         {
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             string tag = "</TotalPlayTime>";
             Calculation_System.TextBoxInsert(txtMsbtText, tag);
         }
@@ -1213,7 +1414,10 @@ namespace MSBT_Editor
         {
             var strbytes = Encoding.GetEncoding("utf-16BE").GetBytes(textBox32.Text);
             textBox33.Text = "";
-            foreach (var hexbit in strbytes) textBox33.AppendText(Environment.NewLine + hexbit.ToString("X2"));
+            foreach (var hexbit in strbytes)
+            {
+                textBox33.AppendText(Environment.NewLine + hexbit.ToString("X2"));
+            }
         }
 
         private void Button30_Click(object sender, EventArgs e)
@@ -1244,21 +1448,31 @@ namespace MSBT_Editor
             //    richTextBox1.Paste();
             //    pos++;
             //}
-
         }
 
         private void BtnReloadTvwMsbfFlow_Click(object sender, EventArgs e)
         {
-            var yesno = MessageBox.Show("ツリーを更新しますか？", "質問", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
-            if (yesno == DialogResult.No) return;
+            var yesno = MessageBox.Show
+            (
+                "ツリーを更新しますか？",
+                "質問",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Information
+            );
+            if (yesno == DialogResult.No)
+            {
+                return;
+            }
             FEN1 fen1 = new FEN1();
-            try { FEN1.TreeLoder(fen1.Item2); }
+            try
+            {
+                FEN1.TreeLoder(fen1.Item2);
+            }
             catch (Exception ex)
             {
                 tvwMsbfFlow.Nodes.Clear();
                 Console.WriteLine("errrrrrror");
             }
-
         }
 
         private void ChkShowTvwMsbfFlow_CheckedChanged(object sender, EventArgs e)
@@ -1305,20 +1519,20 @@ namespace MSBT_Editor
 
         private void BtnInsertCustomIconTag_Click(object sender, EventArgs e)
         {
-
             var Tag = txtCustomIconHex.Text;
             var StrCount = Tag.Length;
 
             //末尾6バイト(12文字)の制限
             //例:<UserIcon="000E0003 00350002003A">
-            if (StrCount != 12) return;
-
-            if (lstListsInsideMsbt.Items.Count < 1) return;
-
+            if (StrCount != 12)
+            {
+                return;
+            }
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
             Tag = "<UserIcon=\"000E0003" + Tag + "\">";
-
-
-
 
             Calculation_System.TextBoxInsert(txtMsbtText, Tag);
         }
@@ -1328,15 +1542,18 @@ namespace MSBT_Editor
             KeyPressEventSupport.OnlyHexChar(e, true);
         }
 
-
-
         private void BtnInsertSoundEffectTag_Click(object sender, EventArgs e)
         {
             //<SE="SE_BV_KOOPA_BURN_RUN">
             var Tag = txtSoundEffectName.Text;
-            if (Tag == string.Empty) return;
-
-            if (lstListsInsideMsbt.Items.Count < 1) return;
+            if (Tag == string.Empty)
+            {
+                return;
+            }
+            if (lstListsInsideMsbt.Items.Count < 1)
+            {
+                return;
+            }
 
             Tag = "<SE=\"" + Tag + "\">";
             Calculation_System.TextBoxInsert(txtMsbtText, Tag);
@@ -1345,10 +1562,11 @@ namespace MSBT_Editor
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
             var ResourceRarcFolder = Path.GetDirectoryName(Application.ExecutablePath) + "\\res\\" + "ARC";
-            if (Directory.Exists(ResourceRarcFolder)) Directory.Delete(ResourceRarcFolder, true);
+            if (Directory.Exists(ResourceRarcFolder))
+            {
+                Directory.Delete(ResourceRarcFolder, true);
+            }
         }
-
-
 
         private void LlbGitHubReleasesUrl_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
@@ -1390,12 +1608,14 @@ namespace MSBT_Editor
             txtUnknownTag.Text = string.Empty;
             var Sorted = OldStrings.OrderBy(sort => sort).ToArray();
 
-            foreach (var tes in Sorted) txtUnknownTag.AppendText(tes + Environment.NewLine);
+            foreach (var tes in Sorted)
+            {
+                txtUnknownTag.AppendText(tes + Environment.NewLine);
+            }
         }
 
         private void ChkMsbAutoSave_CheckedChanged(object sender, EventArgs e)
         {
-
             if (chkMsbAutoSave.Checked == false)
             {
                 s_useAutoSave = false;
@@ -1412,11 +1632,16 @@ namespace MSBT_Editor
         }
         private void LstFilesInsideRarc_SelectedIndexChanged(object sender, EventArgs e/*EventHandler e*/)
         {
-
             var SaveSelect = DialogResult;
 
-            if (Dialog.ArcInsideMsbtAndMsbfPath.Count < 1) return;
-            if (lstFilesInsideRarc.Items.Count < 0) return;
+            if (Dialog.ArcInsideMsbtAndMsbfPath.Count < 1)
+            {
+                return;
+            }
+            if (lstFilesInsideRarc.Items.Count < 0)
+            {
+                return;
+            }
 
             var Index = lstFilesInsideRarc.SelectedIndex;
             if (Properties.Settings.Default.ARCListIndexOld == -1)
@@ -1457,30 +1682,39 @@ namespace MSBT_Editor
             //if (Path.GetExtension()) ;
             var OldPath = lstFilesInsideRarc.Items[Properties.Settings.Default.ARCListIndexOld].ToString();
 
-
             var MsbtOldName = stbOpenedMsbtName.Text;
             var MsbfOldName = stbOpenedMsbfName.Text;
 
             bool IsMsbtDef = false;
             bool IsMsbfDef = false;
 
-            if (MsbtOldName == Language.FileReadStatusJP[0]) IsMsbtDef = true;
-            if (MsbfOldName == Language.FileReadStatusJP[1]) IsMsbfDef = true;
-
+            if (MsbtOldName == Language.FileReadStatusJP[0])
+            {
+                IsMsbtDef = true;
+            }
+            if (MsbfOldName == Language.FileReadStatusJP[1])
+            {
+                IsMsbfDef = true;
+            }
 
             if (Properties.Settings.Default.言語 == "EN")
             {
-                if (MsbtOldName == Language.FileReadStatusUS[0]) IsMsbtDef = true;
-                if (MsbfOldName == Language.FileReadStatusUS[1]) IsMsbfDef = true;
+                if (MsbtOldName == Language.FileReadStatusUS[0])
+                {
+                    IsMsbtDef = true;
+                }
+                if (MsbfOldName == Language.FileReadStatusUS[1])
+                {
+                    IsMsbfDef = true;
+                }
             }
 
             if ((PathExtention == ".msbt") && (Dialog.Save_Path_Msbt != lstFilesInsideRarc.Text))
             {
-
                 if ((s_useAutoSave == false) && (MsbtOldName != PathFileName) && IsMsbtDef == false)
                 {
-                    SaveSelect =
-                    MessageBox.Show(
+                    SaveSelect = MessageBox.Show
+                    (
                         "ファイルを上書きしますか？",
                         "質問",
                         MessageBoxButtons.YesNo,
@@ -1498,7 +1732,6 @@ namespace MSBT_Editor
                         //    throw new Exception("ARCListの数が0以下です。");
                         //}
                         //this.ARCListBox.SelectedIndexChanged += new EventHandler(this.ARCListBox_SelectedIndexChanged);
-
                         return;
                     }
                     //ARCListBox.Enabled = true;
@@ -1511,18 +1744,18 @@ namespace MSBT_Editor
                 if (s_useAutoSave == true)
                 {
                     SaveSelect = DialogResult.Yes;
-                    if (File.Exists(Dialog.Save_Path_Msbt)) Dialog.Save(Dialog.Save_Path_Msbt, 1);
+                    if (File.Exists(Dialog.Save_Path_Msbt))
+                    {
+                        Dialog.Save(Dialog.Save_Path_Msbt, 1);
+                    }
                 }
-
-
-
             }
             else if ((PathExtention == ".msbf") && (Dialog.Save_Path_Msbf != lstFilesInsideRarc.Text))
             {
                 if ((s_useAutoSave == false) && (MsbfOldName != PathFileName) && IsMsbfDef == false)
                 {
-                    SaveSelect =
-                    MessageBox.Show(
+                    SaveSelect = MessageBox.Show
+                    (
                         "ファイルを上書きしますか？",
                         "質問",
                         MessageBoxButtons.YesNo,
@@ -1533,7 +1766,10 @@ namespace MSBT_Editor
 
                 if (DialogResult.No == SaveSelect)
                 {
-                    if (Properties.Settings.Default.ARCListIndexOld < 0) return;
+                    if (Properties.Settings.Default.ARCListIndexOld < 0)
+                    {
+                        return;
+                    }
                     lstFilesInsideRarc.SelectedIndex = Properties.Settings.Default.ARCListIndexOld;
                     lstFilesInsideRarc.Enabled = true;
                     return;
@@ -1542,7 +1778,10 @@ namespace MSBT_Editor
                 if (s_useAutoSave == true)
                 {
                     SaveSelect = DialogResult.Yes;
-                    if (File.Exists(Dialog.Save_Path_Msbf)) Dialog.Save(Dialog.Save_Path_Msbf, 2);
+                    if (File.Exists(Dialog.Save_Path_Msbf))
+                    {
+                        Dialog.Save(Dialog.Save_Path_Msbf, 2);
+                    }
                 }
             }
             else
@@ -1557,22 +1796,20 @@ namespace MSBT_Editor
             {
                 txtMsbtText.Clear();
                 txtReadOnlyMsbtText.Clear();
+                txtAtr1SoundID.Clear();
+                txtAtr1SimpleCameraID.Clear();
+                txtAtr1DialogID.Clear();
+                txtAtr1WindowID.Clear();
+                txtAtr1EventCameraID.Clear();
+                txtAtr1MessageAreaID.Clear();
+                txtAtr1Unknown6.Clear();
+                txtAtr1SpecialTextOffset.Clear();
+                txtAtr1SpecialText.Clear();
+                txtSelectedMsbtListName.Clear();
+                lblMsbtListSelectIndex.Text = "0x00";
             }
-            txtAtr1SoundID.Clear();
-            txtAtr1SimpleCameraID.Clear();
-            txtAtr1DialogID.Clear();
-            txtAtr1WindowID.Clear();
-            txtAtr1EventCameraID.Clear();
-            txtAtr1MessageAreaID.Clear();
-            txtAtr1Unknown6.Clear();
-            txtAtr1SpecialTextOffset.Clear();
-            txtAtr1SpecialText.Clear();
-            txtSelectedMsbtListName.Clear();
-            lblMsbtListSelectIndex.Text = "0x00";
 
             Dialog.FileCheck(Dialog.ArcInsideMsbtAndMsbfPath[Index]);
-
-
 
             this.lstFilesInsideRarc.SelectedIndexChanged += new EventHandler(this.LstFilesInsideRarc_SelectedIndexChanged);
 

--- a/MSBT_Editor/Formsys/KeyPressEventSupport.cs
+++ b/MSBT_Editor/Formsys/KeyPressEventSupport.cs
@@ -13,7 +13,6 @@ namespace MSBT_Editor.Formsys
     /// </summary>
     public class KeyPressEventSupport
     {
-
         /// <summary>
         /// KeyPressEventArgのKeyCharの入力を16進数しか入力できないようにします。
         /// </summary>
@@ -39,7 +38,8 @@ namespace MSBT_Editor.Formsys
         /// KeyPressEventArgのKeyCharの入力を10進数しか入力できないようにします。
         /// </summary>
         /// <param name="e">TextBoxのKeyPressEventArgs</param>
-        public static void OnlyDecChar(KeyPressEventArgs e) {
+        public static void OnlyDecChar(KeyPressEventArgs e)
+        {
             var Include0to9 = (e.KeyChar < '0' || '9' < e.KeyChar);
             e.Handled = true;
             if (!(Include0to9) || e.KeyChar == '\b')
@@ -53,13 +53,9 @@ namespace MSBT_Editor.Formsys
         /// </summary>
         /// <param name="e">TextBoxのKeyPressEventArgs</param>
         /// <param name="canWrite">Trueで書き込みが可能になります</param>
-        public static void CanWriteChar(KeyPressEventArgs e ,bool canWrite)
+        public static void CanWriteChar(KeyPressEventArgs e, bool canWrite)
         {
             e.Handled = !canWrite;
         }
-
-
-
-        
     }
 }

--- a/MSBT_Editor/Formsys/Language.cs
+++ b/MSBT_Editor/Formsys/Language.cs
@@ -7,15 +7,33 @@ using System.Windows.Forms;
 
 namespace MSBT_Editor.Formsys
 {
-    public class Language : objects
+    public class Language : Objects
     {
-        private static readonly string[] IconNameJP01 = { "ピーチ", "クッパ", "キノピオ", "マリオ", "マリオ2", "チコ", "ヨッシー", "腹ペコチコ", "ルイージ", "ベビーチコ", "アシストチコ", "ベーゴマン", "クリボー", "星ウサギ" };
-        private static readonly string[] IconNameJP02 = { "彗星メダル", "コイン×3", "カラフルスターピース", "イエローチップ", "スターピース紫", "シルバースター", "スター", "グランドスター", "ブロンズスター", "コイン", "パープルコイン", "1UPキノコ", "ライフアップキノコ", "ブルースター", "スターリング", "ヨッシーキャプチャー花", "ココナッツ", "ブルーチップ", "バルーンフルーツ", "中間ポイント", "グランドブロンズスター" };
-        private static readonly string[] IconNameJP03 = { "ポインター", "2Pポインター", "ハンドポインター選択", "Wiiリモコン", "Aボタン", "Bボタン", "Cボタン", "Zボタン", "十字ボタン", "十字ボタン下", "十字ボタン上", "スティック", "ヌンチャク", "照準", "マイナスボタン", "プラスボタン", "×(かける)アイコン", "グリーンコメット", "銀の王冠", "銀の王冠宝石付き", "金の王冠", "手紙", "矢印下", "ストップウォッチ", "1ボタン", "2ボタン", "ホームボタン", "ハンドポインター握り", "ハンドポインター", "？マーク", "イエローコメット", "？マーク緑", "空のスター", "空の彗星メダル", "空の彗星", "隠しスター", "ブロンズコメット" };
+        private static readonly string[] IconNameJP01 =
+        {
+            "ピーチ", "クッパ", "キノピオ", "マリオ", "マリオ2", "チコ", "ヨッシー", "腹ペコチコ",
+            "ルイージ","ベビーチコ", "アシストチコ", "ベーゴマン", "クリボー", "星ウサギ"
+        };
+        private static readonly string[] IconNameJP02 =
+        {
+            "彗星メダル", "コイン×3", "カラフルスターピース", "イエローチップ", "スターピース紫",
+            "シルバースター","スター", "グランドスター", "ブロンズスター", "コイン", "パープルコイン",
+            "1UPキノコ", "ライフアップキノコ", "ブルースター", "スターリング", "ヨッシーキャプチャー花",
+            "ココナッツ", "ブルーチップ", "バルーンフルーツ", "中間ポイント", "グランドブロンズスター"
+        };
+        private static readonly string[] IconNameJP03 =
+        {
+            "ポインター", "2Pポインター", "ハンドポインター選択", "Wiiリモコン", "Aボタン", "Bボタン",
+            "Cボタン", "Zボタン", "十字ボタン", "十字ボタン下", "十字ボタン上", "スティック", "ヌンチャク",
+            "照準", "マイナスボタン", "プラスボタン", "×(かける)アイコン", "グリーンコメット", "銀の王冠",
+            "銀の王冠宝石付き", "金の王冠", "手紙", "矢印下", "ストップウォッチ", "1ボタン", "2ボタン",
+            "ホームボタン", "ハンドポインター握り", "ハンドポインター", "？マーク", "イエローコメット",
+            "？マーク緑", "空のスター", "空の彗星メダル", "空の彗星", "隠しスター", "ブロンズコメット"
+        };
         
         //<>で挟んでいる理由は、ファイル名に<>を付けることが出来ないので付けています。
         //<>を付けることにより、ファイルを読み込んでいるときにこの項目を削除させない意図があります。
-        public static readonly string[] FileReadStatusJP = { "<MSBTファイルなし>","<MSBFファイルなし>","<ARCファイルなし>" } ;
+        public static readonly string[] FileReadStatusJP = { "<MSBTファイルなし>","<MSBFファイルなし>","<ARCファイルなし>" };
         public static readonly string[] FileReadStatusUS = { "<No MSBT Open>", "<No MSBF Open>", "<No ARC Open>" };
 
         public static void Language_Check()
@@ -44,7 +62,8 @@ namespace MSBT_Editor.Formsys
             }
         }
 
-        public static string FLW2_List_Language(int num) {
+        public static string FLW2_List_Language(int num)
+        {
             switch (Properties.Settings.Default.言語)
             {
                 case "日本語":
@@ -56,9 +75,11 @@ namespace MSBT_Editor.Formsys
             }
         }
 
-        public static string FLW_List_JP(int num) {
+        public static string FLW_List_JP(int num)
+        {
             string str = "";
-            switch (num) {
+            switch (num)
+            {
                 case 0x0001:
                     str = "会話決定とジャンプ？";
                     break;
@@ -74,7 +95,6 @@ namespace MSBT_Editor.Formsys
                 default:
                     str ="エラー "+num.ToString();
                     break;
-
             }
             return str;
         }
@@ -103,7 +123,8 @@ namespace MSBT_Editor.Formsys
             return str;
         }
 
-        public static void JP(){
+        public static void JP()
+        {
             tssl1.Text = "開いたファイル：";
             tssl6.Text = "保存したファイル：";
             //menu
@@ -163,7 +184,10 @@ namespace MSBT_Editor.Formsys
 
             labeltxt29.Text = "ジャンプ先1（真）";
             labeltxt30.Text = "ジャンプ先2（偽）";
-            labeltxt33.Text = "※まだすべての機能を解明できていないため、" + Environment.NewLine + "　不具合が発生する可能性があります";
+            labeltxt33.Text
+                = "※まだすべての機能を解明できていないため、"
+                + Environment.NewLine
+                + "　不具合が発生する可能性があります";
             labeltxt34.Text = "この項目は名前が不要です";
             labeltxt35.Text = "名前必須(Flowなどを省いた名前)";
             labeltxt31.Text = "不明";
@@ -255,10 +279,10 @@ namespace MSBT_Editor.Formsys
             combo5.Items.Clear();
             combo6.Items.Clear();
             combo7.Items.Clear();
-            string[] cb1 = { "ブラック" , "レッド" , "グリーン" , "ブルー" , "イエロー" , "パープル" , "オレンジ" , "グレー" , "カラーエンドタグ" };
-            string[] cb2 = { "改行" , "次のページ" ,"終了" };
-            string[] cb3 = { "小" , "普通" , "大" };
-            string[] cb4 = { "横方向" , "縦方向"};
+            string[] cb1 = { "ブラック", "レッド", "グリーン", "ブルー", "イエロー", "パープル", "オレンジ", "グレー", "カラーエンドタグ" };
+            string[] cb2 = { "改行", "次のページ", "終了" };
+            string[] cb3 = { "小", "普通", "大" };
+            string[] cb4 = { "横方向", "縦方向"};
             combo1.Text = "ブラック";
             combo1.Items.AddRange(cb1);
             combo2.Text = "改行";
@@ -457,7 +481,25 @@ namespace MSBT_Editor.Formsys
             button13.Hide();
 
             //all icons in one combo
-            combo5.Items.AddRange(new object[] { "A Button", "B Button", "C Button", "Wii Remote", "Nunchuck", "1 Button", "2 Button", "Power Star", "Launch Star", "Pull Star", "P1 Pointer", "Purple Star Bit", "Coconut", "Down Arrow", "Star Bunny", "Control Stick", "X Icon", "Coin", "Mario Icon", "D-Pad", "Pull Star Chip", "Star Chip", "HOME Button", "Minus Button", "Plus Button", "Z Button", "Silver Star", "Grand Star", "Luigi Icon", "P2 Pointer", "Purple Coin", "Green Comet", "Golden Crown", "Aim Target", "Bowser Icon", "Star Pointer Hand (Selected)", "Star Pointer Hand (Pointing)", "Star Pointer Hand (Selecting)", "Rainbow Star Bit", "Peach Icon", "Letter", "Question Mark", "One Up Mushroom", "Life Up Mushroom", "Hungry Luma", "Luma", "Power Star Comet", "Green Question Mark", "Timer Icon", "Young Master Luma", "Yoshi", "Comet Medal", "Silver Crown", "Yoshi Grapple", "Checkpoint Flag", "Empty Power Star", "Empty Comet Medal", "Empty Comet", "Empty Hidden Star", "Bronze Star", "Blimp Fruit", "Large Silver Crown", "Bronze Grand Star", "Topman", "Goomba", "Coin Stack", "D-Pad Up", "D-Pad Down", "Co-Star Luma", "Toad", "Bronze Comet" });
+            combo5.Items.AddRange(new object[]
+                {
+                    "A Button", "B Button", "C Button", "Wii Remote", "Nunchuck", "1 Button",
+                    "2 Button", "Power Star", "Launch Star", "Pull Star", "P1 Pointer",
+                    "Purple Star Bit", "Coconut", "Down Arrow", "Star Bunny", "Control Stick",
+                    "X Icon", "Coin", "Mario Icon", "D-Pad", "Pull Star Chip", "Star Chip",
+                    "HOME Button", "Minus Button", "Plus Button", "Z Button", "Silver Star",
+                    "Grand Star", "Luigi Icon", "P2 Pointer", "Purple Coin", "Green Comet",
+                    "Golden Crown", "Aim Target", "Bowser Icon", "Star Pointer Hand (Selected)",
+                    "Star Pointer Hand (Pointing)", "Star Pointer Hand (Selecting)",
+                    "Rainbow Star Bit", "Peach Icon", "Letter", "Question Mark", "One Up Mushroom",
+                    "Life Up Mushroom", "Hungry Luma", "Luma", "Power Star Comet",
+                    "Green Question Mark", "Timer Icon", "Young Master Luma", "Yoshi",
+                    "Comet Medal", "Silver Crown", "Yoshi Grapple", "Checkpoint Flag",
+                    "Empty Power Star", "Empty Comet Medal", "Empty Comet", "Empty Hidden Star",
+                    "Bronze Star", "Blimp Fruit", "Large Silver Crown", "Bronze Grand Star",
+                    "Topman", "Goomba", "Coin Stack", "D-Pad Up", "D-Pad Down", "Co-Star Luma",
+                    "Toad", "Bronze Comet"
+                });
             combo5.Text = "A Button";
             StatusBarLabelChenger(tssl2, FileReadStatusJP[0], FileReadStatusUS[0]);
             StatusBarLabelChenger(tssl4, FileReadStatusJP[1], FileReadStatusUS[1]);
@@ -470,14 +512,22 @@ namespace MSBT_Editor.Formsys
             //    tssl4.Text = "No MSBF Open";
         }
 
-        public static void StatusBarLabelChenger(ToolStripStatusLabel tssl,string defaultStr,string newStr) {
-            if (tssl.Text != defaultStr) return;
+        public static void StatusBarLabelChenger(ToolStripStatusLabel tssl, string defaultStr, string newStr)
+        {
+            if (tssl.Text != defaultStr)
+            {
+                return;
+            }
             tssl.Text = newStr;
         }
 
-        public static string DefaultStatusBarLabel(ToolStripStatusLabel tssl,string jp , string us) {
+        public static string DefaultStatusBarLabel(ToolStripStatusLabel tssl,string jp, string us)
+        {
             tssl.Text = jp;
-            if (Properties.Settings.Default.言語 == "日本語") return jp;
+            if (Properties.Settings.Default.言語 == "日本語")
+            {
+                return jp;
+            }
             tssl.Text = us;
             return us;
         }

--- a/MSBT_Editor/Formsys/objects.cs
+++ b/MSBT_Editor/Formsys/objects.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 
 namespace MSBT_Editor.Formsys
 {
-    public class objects
+    public class Objects
     {
         protected static TextBox txtb1 = Form1.Form1Instance.txtMsbtText;
         protected static TextBox txtb2 = Form1.Form1Instance.textBox2;
@@ -76,7 +76,6 @@ namespace MSBT_Editor.Formsys
         protected static Label labeltxt17 = Form1.Form1Instance.lblRubiTagRubiCount;
         protected static Label labeltxt18 = Form1.Form1Instance.lblRubiTagKanjiCount;
         protected static Label labeltxt19 = Form1.Form1Instance.lblTimerTagDelayTime;
-
 
         //label 20～29
         protected static Label labeltxt20 = Form1.Form1Instance.lblCharacterIconTag;
@@ -177,6 +176,5 @@ namespace MSBT_Editor.Formsys
 
         //
         protected static TextBox unknowntag = Form1.Form1Instance.txtUnknownTag;
-       
     }
 }

--- a/MSBT_Editor/MSBFsys/MSBF_Data.cs
+++ b/MSBT_Editor/MSBFsys/MSBF_Data.cs
@@ -7,7 +7,7 @@ using MSBT_Editor.Formsys;
 
 namespace MSBT_Editor.MSBFsys
 {
-    public class MSBF_Data : objects
+    public class MSBF_Data : Objects
     {
         //MSBTヘッダー
         private static string magic;
@@ -22,9 +22,6 @@ namespace MSBT_Editor.MSBFsys
         private static Int16 unknown7;
         private static Int16 unknown8;
         private static Int16 unknown9;
-
-        
-        
 
         public string Magic
         {

--- a/MSBT_Editor/MSBFsys/MSBF_Header.cs
+++ b/MSBT_Editor/MSBFsys/MSBF_Header.cs
@@ -51,15 +51,15 @@ namespace MSBT_Editor.MSBFsys
             Debugger.MSBF_Text(Unknown9.ToString());
 
             //各セクションの読み込み
-            flw2.Read(br,fs);
-            fen1.Read(br,fs);
+            flw2.Read(br, fs);
+            fen1.Read(br, fs);
 
             fs.Close();
             br.Close();
         }
 
-        public void Write(string filepath) {
-
+        public void Write(string filepath)
+        {
             Console.WriteLine("MSBF処理に入りました");
             FileStream fs = new FileStream(filepath, FileMode.Create);
             BinaryWriter bw = new BinaryWriter(fs);
@@ -89,8 +89,8 @@ namespace MSBT_Editor.MSBFsys
             FEN1 fen1 = new FEN1();
 
             //各セクションの書き込み
-            flw2.Write(bw,fs);
-            var filesize = fen1.Write(bw,fs);
+            flw2.Write(bw, fs);
+            var filesize = fen1.Write(bw, fs);
 
             //ファイルサイズの書き込み
             fs.Seek(MSBF_File_Size_pos,SeekOrigin.Begin);
@@ -99,7 +99,6 @@ namespace MSBT_Editor.MSBFsys
             //終了処理
             fs.Close();
             bw.Close();
-
         }
     }
 }

--- a/MSBT_Editor/MSBT_Editor.csproj
+++ b/MSBT_Editor/MSBT_Editor.csproj
@@ -77,7 +77,7 @@
     </Compile>
     <Compile Include="Formsys\KeyPressEventSupport.cs" />
     <Compile Include="Formsys\Language.cs" />
-    <Compile Include="Formsys\objects.cs" />
+    <Compile Include="Formsys\Objects.cs" />
     <Compile Include="MSBX\IMSBX_Data.cs" />
     <Compile Include="MSBFsys\MSBF_Data.cs" />
     <Compile Include="MSBFsys\MSBF_Header.cs" />

--- a/MSBT_Editor/MSBTsys/MSBT_Data.cs
+++ b/MSBT_Editor/MSBTsys/MSBT_Data.cs
@@ -6,13 +6,11 @@ using System.Threading.Tasks;
 using System.IO;
 using MSBT_Editor.Formsys;
 using MSBT_Editor.Sectionsys;
+
 namespace MSBT_Editor.MSBTsys
 {
-
-
-    public class MSBT_Data:objects
+    public class MSBT_Data : Objects
     {
-
         //MSBTヘッダー
         private static string magic;
         private static Int16 endian;
@@ -29,10 +27,12 @@ namespace MSBT_Editor.MSBTsys
         public static List<string> Txt2_Text_List;
         public static List<string> Atr1SpecialText;
 
-        public struct Data_List {
+        public struct Data_List
+        {
             public List<string> Text;
             public List<ATR1.AttributeData> Item;
-            public Data_List(List<string> list1, List<ATR1.AttributeData> list2) {
+            public Data_List(List<string> list1, List<ATR1.AttributeData> list2)
+            {
                 this.Text = new List<string>();
                 this.Item = new List<ATR1.AttributeData>();
                 this.Text = list1;

--- a/MSBT_Editor/MSBTsys/MSBT_Header.cs
+++ b/MSBT_Editor/MSBTsys/MSBT_Header.cs
@@ -9,7 +9,6 @@ using CS = MSBT_Editor.FileSys.Calculation_System;
 using EN = System.Environment;
 using MSBT_Editor.Sectionsys;
 
-
 namespace MSBT_Editor.MSBTsys
 {
     public class MSBT_Header : MSBT_Data
@@ -41,14 +40,17 @@ namespace MSBT_Editor.MSBTsys
             //各セクション読み取り
             lbl1.Read(br, fs);
             atr1.Read(br, fs);
-            txt2.Read(br,fs);
+            txt2.Read(br, fs);
             
             //データ記録
-            MSBT_All_Data = new Data_List(new List<string>(TXT2.Text_Data) , new List<ATR1.AttributeData>(atr1.AttributeDataList));
+            MSBT_All_Data = new Data_List(new List<string>(TXT2.Text_Data), new List<ATR1.AttributeData>(atr1.AttributeDataList));
             Atr1SpecialText = new List<string>();
             Atr1SpecialText = ATR1.SpecialTextList;
 
-            if (MsbtListBox.Items.Count > 0) MsbtListBox.SelectedIndex = 0;
+            if (MsbtListBox.Items.Count > 0)
+            {
+                MsbtListBox.SelectedIndex = 0;
+            }
 
             //終了処理
             fs.Close();
@@ -62,8 +64,8 @@ namespace MSBT_Editor.MSBTsys
             }
         }
 
-
-        public void Write(string filepath) {
+        public void Write(string filepath)
+        {
             Console.WriteLine("MSBT処理に入りました");
 
             FileStream fs = new FileStream(filepath, FileMode.Create);
@@ -95,16 +97,13 @@ namespace MSBT_Editor.MSBTsys
             TXT2 txt2 = new TXT2();
 
             //各セクションの書き込み
-            lbl1.Write(bw,fs);
-            atr1.Write(bw,fs);
-            txt2.Write(bw,fs,MSBT_File_Size_pos);
+            lbl1.Write(bw, fs);
+            atr1.Write(bw, fs);
+            txt2.Write(bw, fs, MSBT_File_Size_pos);
 
             //終了処理
             fs.Close();
             bw.Close();
-            
-
         }
-
     }
 }

--- a/MSBT_Editor/MSBTsys/MSBT_TagData.cs
+++ b/MSBT_Editor/MSBTsys/MSBT_TagData.cs
@@ -26,15 +26,24 @@ namespace MSBT_Editor.MSBTsys
         /// <returns></returns>
         public static bool CanTextInsert(ListBox msbtList, ComboBox comboBox)
         {
-            if (msbtList.Items.Count < 1) return false;
+            if (msbtList.Items.Count < 1)
+            {
+                return false;
+            }
             var Index = comboBox.SelectedIndex;
-            if (Index == -1) return false;
+            if (Index == -1)
+            {
+                return false;
+            }
             return true;
         }
 
         public static void TextBoxTagInsert(TextBox tb, string str)
         {
-            if (str == string.Empty) return;
+            if (str == string.Empty)
+            {
+                return;
+            }
             tb.SelectedText = str;
         }
 
@@ -98,7 +107,8 @@ namespace MSBT_Editor.MSBTsys
 
         public class CenterTag : ITagDecide
         {
-            private readonly string[] Center = {
+            private readonly string[] Center =
+            {
                 "</XCenter>",
                 "</YCenter>"
             };
@@ -134,15 +144,20 @@ namespace MSBT_Editor.MSBTsys
                 {
                     if (MsbtTextBox.Text.IndexOf("</End>") != -1)
                     {
-
-                        MessageBox.Show("</End>が二つ以上あるとデータが" + "\n\r" + "破損するので挿入をキャンセルしました", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show
+                        (
+                            "</End>が二つ以上あるとデータが" +
+                            "\r\n" +
+                            "破損するので挿入をキャンセルしました",
+                            "エラー",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error
+                        );
                         return;
                     }
                 }
                 TextBoxTagInsert(MsbtTextBox, Tag);
             }
-
-
         }
     }
 }

--- a/MSBT_Editor/Properties/Resources.Designer.cs
+++ b/MSBT_Editor/Properties/Resources.Designer.cs
@@ -11,7 +11,6 @@
 namespace MSBT_Editor.Properties {
     using System;
     
-    
     /// <summary>
     ///   ローカライズされた文字列などを検索するための、厳密に型指定されたリソース クラスです。
     /// </summary>
@@ -22,23 +21,26 @@ namespace MSBT_Editor.Properties {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
-        
+    internal class Resources
+    {
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources()
+        {
         }
         
         /// <summary>
         ///   このクラスで使用されているキャッシュされた ResourceManager インスタンスを返します。
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
             get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MSBT_Editor.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
@@ -51,11 +53,14 @@ namespace MSBT_Editor.Properties {
         ///   現在のスレッドの CurrentUICulture プロパティをオーバーライドします。
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
@@ -63,8 +68,10 @@ namespace MSBT_Editor.Properties {
         /// <summary>
         ///   型 System.Byte[] のローカライズされたリソースを検索します。
         /// </summary>
-        internal static byte[] ARCTool_ver0_1_5_0 {
-            get {
+        internal static byte[] ARCTool_ver0_1_5_0
+        {
+            get
+            {
                 object obj = ResourceManager.GetObject("ARCTool_ver0_1_5_0", resourceCulture);
                 return ((byte[])(obj));
             }
@@ -73,8 +80,10 @@ namespace MSBT_Editor.Properties {
         /// <summary>
         ///   型 System.Byte[] のローカライズされたリソースを検索します。
         /// </summary>
-        internal static byte[] ARCTool_ver0_1_5_0_deps {
-            get {
+        internal static byte[] ARCTool_ver0_1_5_0_deps
+        {
+            get
+            {
                 object obj = ResourceManager.GetObject("ARCTool_ver0_1_5_0_deps", resourceCulture);
                 return ((byte[])(obj));
             }
@@ -83,8 +92,10 @@ namespace MSBT_Editor.Properties {
         /// <summary>
         ///   型 System.Byte[] のローカライズされたリソースを検索します。
         /// </summary>
-        internal static byte[] ARCTool_ver0_1_5_0_runtimeconfig {
-            get {
+        internal static byte[] ARCTool_ver0_1_5_0_runtimeconfig
+        {
+            get
+            {
                 object obj = ResourceManager.GetObject("ARCTool_ver0_1_5_0_runtimeconfig", resourceCulture);
                 return ((byte[])(obj));
             }
@@ -93,8 +104,10 @@ namespace MSBT_Editor.Properties {
         /// <summary>
         ///   型 System.Byte[] のローカライズされたリソースを検索します。
         /// </summary>
-        internal static byte[] ARCTool_ver0_1_5_01 {
-            get {
+        internal static byte[] ARCTool_ver0_1_5_01
+        {
+            get
+            {
                 object obj = ResourceManager.GetObject("ARCTool_ver0_1_5_01", resourceCulture);
                 return ((byte[])(obj));
             }
@@ -103,8 +116,10 @@ namespace MSBT_Editor.Properties {
         /// <summary>
         ///   (アイコン) に類似した型 System.Drawing.Icon のローカライズされたリソースを検索します。
         /// </summary>
-        internal static System.Drawing.Icon アイコン {
-            get {
+        internal static System.Drawing.Icon アイコン
+        {
+            get
+            {
                 object obj = ResourceManager.GetObject("アイコン", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }
@@ -113,8 +128,10 @@ namespace MSBT_Editor.Properties {
         /// <summary>
         ///   (アイコン) に類似した型 System.Drawing.Icon のローカライズされたリソースを検索します。
         /// </summary>
-        internal static System.Drawing.Icon タスクバーアイコン {
-            get {
+        internal static System.Drawing.Icon タスクバーアイコン
+        {
+            get
+            {
                 object obj = ResourceManager.GetObject("タスクバーアイコン", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }

--- a/MSBT_Editor/Sectionsys/ATR1.cs
+++ b/MSBT_Editor/Sectionsys/ATR1.cs
@@ -15,7 +15,7 @@ using System.Globalization;
 
 namespace MSBT_Editor.Sectionsys
 {
-    public class ATR1 : objects
+    public class ATR1 : Objects
     {
         private static string s_magic;
         private static int s_sec_size;
@@ -98,7 +98,6 @@ namespace MSBT_Editor.Sectionsys
 
         public void Read(BinaryReader br, FileStream fs)
         {
-
             AttributeDataList = new List<AttributeData>();
             SpecialTextList = new List<string>();
 
@@ -141,7 +140,6 @@ namespace MSBT_Editor.Sectionsys
             int count = AttributeDataList.Count;
             for (int j = 0; j < count; j++)
             {
-
                 string SpecialText;
                 if (count - 1 == j)
                 {
@@ -157,12 +155,14 @@ namespace MSBT_Editor.Sectionsys
             }
         }
 
-        public static byte ATR1TextBoxChange(TextBox textBox,byte changeData)
+        public static byte ATR1TextBoxChange(TextBox textBox, byte changeData)
         {
             var TextBoxByteData = changeData;
-            
-            if (textBox.Text.Length != 2) return TextBoxByteData;
 
+            if (textBox.Text.Length != 2)
+            {
+                return TextBoxByteData;
+            }
             TextBoxByteData = byte.Parse(textBox.Text, NumberStyles.HexNumber);
 
             return TextBoxByteData;
@@ -170,29 +170,39 @@ namespace MSBT_Editor.Sectionsys
 
         public static void ATR1TextBoxChange(TextBox textBox, short changeData)
         {
-            if (MsbtListBox.Items.Count < 1) return;
+            if (MsbtListBox.Items.Count < 1)
+            {
+                return;
+            }
             var TextCount = textBox.Text.Length;
-            if (TextCount != 4) return;
+            if (TextCount != 4)
+            {
+                return;
+            }
         }
-        public static void ATR1_Change(TextBox textbox)
+        public static void ATR1_Change(TextBox tb)
         {
-            if (MsbtListBox.Items.Count < 1) return;
+            if (MsbtListBox.Items.Count < 1)
+            {
+                return;
+            }
             byte bit = 0x01;
             short sh = 0x0000;
-            var strnum = textbox.Text.Length;
+            var strnum = tb.Text.Length;
 
             if (strnum == 2)
             {
-                bit = byte.Parse(textbox.Text, System.Globalization.NumberStyles.HexNumber);
+                bit = byte.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber);
             }
             else if (strnum == 4)
             {
-                sh = short.Parse(textbox.Text, System.Globalization.NumberStyles.HexNumber);
+                sh = short.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber);
             }
 
             ATR1.AttributeData element = MSBT_Data.MSBT_All_Data.Item[MsbtListBox.SelectedIndex];
 
-            switch (textbox.Name)
+            //要リファクタリング　テキストボックス名リネーム時にここの編集も必要で、保守性に欠ける
+            switch (tb.Name)
             {
                 case "txtAtr1SoundID":
                     element.SoundID = bit;
@@ -230,7 +240,6 @@ namespace MSBT_Editor.Sectionsys
 
             CS.StringToBytesWriter(bw, (MsbtListBox.Items.Count).ToString("X8"));
             CS.StringToBytesWriter(bw, (12).ToString("X8"));
-
 
             //エントリーの各データを書き込む
             var MSBTAllDataCount = MSBT_Data.MSBT_All_Data.Item.Count();
@@ -276,7 +285,6 @@ namespace MSBT_Editor.Sectionsys
                 fs.Seek(nulloffsetpos[k], SeekOrigin.Begin);
                 bw.Write(CS.StringToBytes(((int)sptextoffset[k]).ToString("X8")));
             }
-
 
             fs.Seek(SectionSizePosition, SeekOrigin.Begin);
             bw.Write(CS.StringToBytes(((int)(sptextend_pos - BasePositionAddress)).ToString("X8")));

--- a/MSBT_Editor/Sectionsys/FEN1.cs
+++ b/MSBT_Editor/Sectionsys/FEN1.cs
@@ -12,7 +12,7 @@ using System.Windows.Forms;
 
 namespace MSBT_Editor.Sectionsys
 {
-    public class FEN1 : objects
+    public class FEN1 : Objects
     {
         private static string magic;
         private static int sec_size;
@@ -55,7 +55,6 @@ namespace MSBT_Editor.Sectionsys
             set
             {
                 //0x3Bは定数です。私の解析では変動なし。
-
                 if (value == 0x3B)
                 {
                     Console.WriteLine("FEN1エントリーサイズ0x3Bでした。");
@@ -69,8 +68,6 @@ namespace MSBT_Editor.Sectionsys
             }
             get => entry;
         }
-
-
 
         public struct Element
         {
@@ -126,8 +123,6 @@ namespace MSBT_Editor.Sectionsys
         private static List<HashData_And_TagItem> HashData;
         private static List<Hash_And_Unknown> HashData_Read;
 
-
-
         public List<Element> Item1
         {
             set => item1 = value;
@@ -161,11 +156,11 @@ namespace MSBT_Editor.Sectionsys
                 var RemoveNullArray = array.Where((x, y) => x.tagflag > 0).ToArray();
                 EntryReadItem = new List<Element>(RemoveNullArray);
             }
-
             return EntryReadItem;
         }
 
-        private static List<ElementTag> EntryNameReader(FileStream fs ,BinaryReader br,int entry ,long pos_secEnd , List<Element> item1) {
+        private static List<ElementTag> EntryNameReader(FileStream fs, BinaryReader br, int entry, long pos_secEnd, List<Element> item1)
+        {
             byte TargetNPCStringCount = 0;
             string TargetNPCName = "";
             int TargetNPCListIndex = 0;
@@ -188,16 +183,13 @@ namespace MSBT_Editor.Sectionsys
                 item2.Add(new ElementTag(TargetNPCName, TargetNPCListIndex));
 
                 tagcounter++;
-
             }
-
             return item2;
         }
 
         private static Hash_And_Unknown HashDataRead(List<Element> Item, int tagcounter, ref int DuplicateCount, uint Hash)
         {
             int ItemIndex = 0;
-
 
             if (tagcounter == 0)
             {
@@ -212,9 +204,7 @@ namespace MSBT_Editor.Sectionsys
             {
                 ItemIndex = tagcounter - (DuplicateCount);
             }
-
             return new Hash_And_Unknown(Item[ItemIndex].tagflag, Hash);
-
         }
 
         public void Read(BinaryReader br, FileStream fs)
@@ -228,7 +218,6 @@ namespace MSBT_Editor.Sectionsys
             long pos_SectionEnd       = 0;
             long pos_EntryOffset      = 0;
             
-
             //ヘッダー情報の読み取り
             Magic        = CS.Byte2Char(br);
             Section_Size = CS.Byte2Int(br);
@@ -242,20 +231,26 @@ namespace MSBT_Editor.Sectionsys
 
             //エントリーの読み込み
             Item1 = EntryReader(br, Entry);
-            foreach(var a in Item1)
-            Debugger.MSBF_Text(a.tagflag.ToString("X4")+a.unknown2.ToString("X4"));
+            foreach (var a in Item1)
+            {
+                Debugger.MSBF_Text(a.tagflag.ToString("X4") + a.unknown2.ToString("X4"));
+            }
 
             //エントリーネームを読み込む
-            Item2 = EntryNameReader(fs,br,Entry,pos_SectionEnd,Item1);
+            Item2 = EntryNameReader(fs, br, Entry, pos_SectionEnd, Item1);
 
             //ツリーの読み込み
-            if(chk1.Checked)TreeLoder(Item2);
+            if (chk1.Checked)
+            {
+                TreeLoder(Item2);
+            }
             
             //パディング
             CS.MSBF_Padding(br, fs.Position);
         }
 
-        public static void TreeLoder(List<ElementTag> Item2) {
+        public static void TreeLoder(List<ElementTag> Item2)
+        {
             //インスタンス生成
             FLW2 flw2 = new FLW2();
 
@@ -263,7 +258,10 @@ namespace MSBT_Editor.Sectionsys
             treeview1.Nodes.Clear();
 
             //ツリーの構成に必要なデータがあるか確認する
-            if ((Item2.Count == 0) || (flw2.Item.Count == 0)) return;
+            if ((Item2.Count == 0) || (flw2.Item.Count == 0))
+            {
+                return;
+            }
             Console.WriteLine(item2.Count);
             //ツリーを構成する
             foreach (var item in Item2.Select((Value, Index) => (Value, Index)))
@@ -294,8 +292,6 @@ namespace MSBT_Editor.Sectionsys
             switch (type)
             {
                 case 1:
-
-                   
                     tn.Nodes.Add(subnodename);
                     var indexfllow1 = flw2.Item.IndexOf(flw2.Item[subfunc]);
                     tn.Nodes[0].Tag = flw2.Item[indexfllow1];
@@ -303,18 +299,19 @@ namespace MSBT_Editor.Sectionsys
                     if (AJA_Find != -1)
                     {
                         var dupeOrEnd = "  「重複/Dupe」";
-                        if (flw2.Item[subfunc].Unknown4 == indexfllow1) dupeOrEnd = "  「終了/End」";
+                        if (flw2.Item[subfunc].Unknown4 == indexfllow1)
+                        {
+                            dupeOrEnd = "  「終了/End」";
+                        }
                         tn.Nodes[0].Text = subnodename + dupeOrEnd;
-
                         break;
                     }
 
-                    if ((flw2.Item[subfunc].Unknown4 != indexfllow1) && (flw2.Item[subfunc].Unknown4.ToString("X4") != "FFFF")){
+                    if ((flw2.Item[subfunc].Unknown4 != indexfllow1) && (flw2.Item[subfunc].Unknown4.ToString("X4") != "FFFF"))
+                    {
                         AllJumpAddres.Add(flw2.Item[subfunc].Unknown4);
                         Treeview_Message_Node_Adder(flw2.Item[indexfllow1], tn.Nodes[0]);
-                        
                     }
-                    
                     break;
                 case 2:
                     var subbranchfunc = flw2.Branch_No[flw2.Item[subfunc].Unknown5];
@@ -326,7 +323,6 @@ namespace MSBT_Editor.Sectionsys
                     //    tn.Nodes[0].Text = subnodename + subbranchfunc.ToString("X") + "  「重複/Dupe」";
                     //    break;
                     //}
-
 
                     BranchNo.Add(subbranchfunc);
                     Treeview_Branch_Node_Adder(flw2.Item[subfunc], tn.Nodes[0]);
@@ -346,7 +342,6 @@ namespace MSBT_Editor.Sectionsys
                     BranchNo.Add(subbranchfunc2);
                     Treeview_Branch_Node_Adder(flw2.Item[subfunc], tn.Nodes[1], 1);
                     AllJumpAddres.Add(subbranchfunc2);
-
                     break;
                 case 3:
                     tn.Nodes.Add(subnodename);
@@ -354,30 +349,27 @@ namespace MSBT_Editor.Sectionsys
                     tn.Nodes[0].Tag = flw2.Item[indexfllow3];
                     var AJA_Find4 = AllJumpAddres.IndexOf(flw2.Item[subfunc].Unknown3);
 
-                    if (AJA_Find4 != -1){
+                    if (AJA_Find4 != -1)
+                    {
                         var dupeOrEnd = "  「重複/Dupe」";
-                        if (flw2.Item[subfunc].Unknown3 == indexfllow3) dupeOrEnd = "  「終了/End」";
+                        if (flw2.Item[subfunc].Unknown3 == indexfllow3)
+                        {
+                            dupeOrEnd = "  「終了/End」";
+                        }
                         tn.Nodes[0].Text = subnodename + dupeOrEnd;
                         break;
                     }
-                    if (EventNo.IndexOf(flw2.Item[indexfllow3].Unknown3) == -1){
-
-                        if ((flw2.Item[subfunc].Unknown3 != indexfllow3) && (flw2.Item[subfunc].Unknown3.ToString("X4") != "FFFF")){
+                    if (EventNo.IndexOf(flw2.Item[indexfllow3].Unknown3) == -1)
+                    {
+                        if ((flw2.Item[subfunc].Unknown3 != indexfllow3) && (flw2.Item[subfunc].Unknown3.ToString("X4") != "FFFF"))
+                        {
                             EventNo.Add(flw2.Item[indexfllow3].Unknown3);
                             AllJumpAddres.Add(flw2.Item[indexfllow3].Unknown3);
                             Treeview_Event_Node_Adder(flw2.Item[indexfllow3], tn.Nodes[0]);
-                            
                         }
-
                     }
-
-                    
                     break;
             }
-
-                
-                
-            
         }
 
         public static void TreeViewNodeAdder(FLW2.flw2_item flw2item, TreeNode tn, int brancno = 0)
@@ -392,7 +384,6 @@ namespace MSBT_Editor.Sectionsys
             //AllJumpAddres.Add(subnode_element.Unknown2);
             TreeView_Fllow_Type_Checker(subfunc, subnode_element.TypeCheck, subnodename, tn);
             //return 0;
-
         }
 
         public static void Treeview_Message_Node_Adder(FLW2.flw2_item flw2item, TreeNode tn, int brancno = 0)
@@ -405,7 +396,6 @@ namespace MSBT_Editor.Sectionsys
             var subnode_element = flw2.Item[subfunc];
             var subnodename = Language.FLW2_List_Language(subnode_element.TypeCheck);
             TreeView_Fllow_Type_Checker(subfunc, subnode_element.TypeCheck, subnodename, tn);
-            
         }
 
         public static void Treeview_Branch_Node_Adder(FLW2.flw2_item flw2item, TreeNode tn, short brancno = 0)
@@ -432,10 +422,7 @@ namespace MSBT_Editor.Sectionsys
             var subnode_element = flw2.Item[subfunc];
             var subnodename = Language.FLW2_List_Language(subnode_element.TypeCheck);
             TreeView_Fllow_Type_Checker(subfunc, subnode_element.TypeCheck, subnodename, tn);
-            
         }
-
-
 
         public int Write(BinaryWriter bw, FileStream fs)
         {
@@ -463,7 +450,8 @@ namespace MSBT_Editor.Sectionsys
             bw.Write(EntrySize);
 
             //一度0でsec_dataを埋める
-            for (int i = 0; i < 0x3B; i++) {
+            for (int i = 0; i < 0x3B; i++)
+            {
                 CS.Null_Writer_Int32(bw, 2);
             }
 
@@ -472,7 +460,8 @@ namespace MSBT_Editor.Sectionsys
                 var hash = CS.MSBT_Hash(item.Value.tagname, 0x3B);
                 HashData_And_TagItem AdderItem;
 
-                if (item.Index == 0){
+                if (item.Index == 0)
+                {
                     AdderItem.tagname = item.Value.tagname;
                     AdderItem.tagnum  = item.Value.tagnum;
                     AdderItem.Hash    = hash;
@@ -517,7 +506,8 @@ namespace MSBT_Editor.Sectionsys
             var hashdata = sorted.ToArray();
             var pos_unknown_and_offsetend = fs.Position;
 
-            foreach (var b in hashdata){
+            foreach (var b in hashdata)
+            {
                 var pos_calculation = (int)(fs.Position - pos_fen1_offset);
                 var str = ((byte)(b.tagname.Length)).ToString("X2");
                 pos_fen1_offset_entry_name.Add(pos_calculation);
@@ -528,21 +518,25 @@ namespace MSBT_Editor.Sectionsys
             }
 
             var sectionend = fs.Position;
-            Console.WriteLine("secend_"+(sectionend-pos_fen1_offset).ToString("X"));
+            Console.WriteLine("secend_" + (sectionend-pos_fen1_offset).ToString("X"));
             fs.Seek(pos_fen1_sec_data, SeekOrigin.Begin);
 
             var hashcounter = 0;
             foreach (var c in hashdata.Select((Value, Index) => new { Value, Index }))
             {
-
                 if (c.Index == 0)
                 {
                     uint valueHash = c.Value.Hash + 1;
                     for (int k = 0; k < valueHash; k++)
                     {
-                        if (c.Value.Hash != k) bw.Write(CS.StringToBytes((0).ToString("X8")));
-                        else bw.Write(CS.StringToBytes(c.Value.tagflag.ToString("X8")));
-
+                        if (c.Value.Hash != k)
+                        {
+                            bw.Write(CS.StringToBytes((0).ToString("X8")));
+                        }
+                        else
+                        {
+                            bw.Write(CS.StringToBytes(c.Value.tagflag.ToString("X8")));
+                        }
                         bw.Write(CS.StringToBytes(pos_fen1_offset_entry_name[c.Index].ToString("X8")));
                         hashcounter++;
                     }
@@ -560,11 +554,9 @@ namespace MSBT_Editor.Sectionsys
                         {
                             bw.Write(CS.StringToBytes((0).ToString("X8")));
                         }
-
                         bw.Write(CS.StringToBytes(pos_fen1_offset_entry_name[c.Index].ToString("X8")));
                     }
                 }
-                
             }
 
             if (pos_unknown_and_offsetend > fs.Position)
@@ -591,14 +583,23 @@ namespace MSBT_Editor.Sectionsys
         public static void FEN1_Item_Change(ListBox lb, TextBox tb)
         {
             //エラー対策
-            if (lb.Items.Count == 0) return;
-            if (tb.Text.Length != 8) return;
+            if (lb.Items.Count == 0)
+            {
+                return;
+            }
+            if (tb.Text.Length != 8)
+            {
+                return;
+            }
 
             //インデックス位置を保持
             var index = lb.SelectedIndex;
 
             //インデックス番号が-1の時0にする
-            if (index == -1) index = 0;
+            if (index == -1)
+            {
+                index = 0;
+            }
 
             //インスタンス生成
             FEN1 fen1 = new FEN1();
@@ -608,12 +609,13 @@ namespace MSBT_Editor.Sectionsys
 
             var numhex = Int32.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber);
 
-            switch (tb.Name.Substring(tb.Name.Length - 2, 2))
+            //要リファクタリング　テキストボックス名リネーム時にここの編集も必要で、保守性に欠ける
+            switch (tb.Name)
             {
-                case "28":
+                case "txtFen1Arg0":
                     item1.tagflag = numhex;
                     break;
-                case "29":
+                case "txtFen1StartIndex":
                     item2.tagnum = numhex;
                     break;
             }

--- a/MSBT_Editor/Sectionsys/FLW2.cs
+++ b/MSBT_Editor/Sectionsys/FLW2.cs
@@ -9,9 +9,10 @@ using CS = MSBT_Editor.FileSys.Calculation_System;
 using MSBT_Editor.MSBFsys;
 using MSBT_Editor.Formsys;
 using System.Windows.Forms;
+
 namespace MSBT_Editor.Sectionsys
 {
-    public class FLW2:objects
+    public class FLW2 : Objects
     {
         //変数宣言
         private static string magic;
@@ -22,41 +23,47 @@ namespace MSBT_Editor.Sectionsys
         private static Int16 unknown3;
         private static Int32 padding;
 
-        public string Magic {
+        public string Magic
+        {
             private set => magic = value;
             get => magic;
         }
 
-        public int Section_Size {
+        public int Section_Size
+        {
             private set => sec_size = value;
             get => sec_size;
         }
 
-        public int Unknown1 {
+        public int Unknown1
+        {
             private set => unknown1 = value;
             get => unknown1;
         }
 
-        public int Unknown2 {
+        public int Unknown2
+        {
             private set => unknown2 = value;
             get => unknown2;
         }
 
-        public Int16 Entry {
+        public Int16 Entry
+        {
             private set => entry = value;
             get => entry;
         }
 
-        public Int16 Unknown3 {
+        public Int16 Unknown3
+        {
             private set => unknown3 = value;
             get => unknown3;
         }
 
-        public int Padding {
+        public int Padding
+        {
             private set => padding = value;
             get => padding;
         }
-
 
         //構造体
         public struct flw2_item
@@ -69,7 +76,10 @@ namespace MSBT_Editor.Sectionsys
             public Int16 Unknown5;
             public flw2_item(Int16 unk0, Int16 unk1, Int16 unk2, Int16 unk3, Int16 unk4, Int16 unk5)
             {
-                if (unk0 < 1 || unk0 > 4) unk0 = 1;
+                if (unk0 < 1 || unk0 > 4)
+                {
+                    unk0 = 1;
+                }
                 TypeCheck = unk0;
                 Unknown1 = unk1;
                 Unknown2 = unk2;
@@ -79,18 +89,19 @@ namespace MSBT_Editor.Sectionsys
             }
         }
 
-
         //リスト宣言
         private static List<flw2_item> item;
         private static List<Int16> branch_no;
         private static List<int> branch_list_no;
 
-        public List<flw2_item> Item{
+        public List<flw2_item> Item
+        {
             set => item = value;
             get => item;
         }
 
-        public List<Int16> Branch_No {
+        public List<Int16> Branch_No
+        {
             set => branch_no = value;
             get => branch_no;
         }
@@ -101,8 +112,8 @@ namespace MSBT_Editor.Sectionsys
             get => branch_list_no;
         }
 
-        public void Read(BinaryReader br, FileStream fs) {
-
+        public void Read(BinaryReader br, FileStream fs)
+        {
             //初期化
             Item = new List<flw2_item>();
             Branch_No = new List<Int16>();
@@ -128,8 +139,8 @@ namespace MSBT_Editor.Sectionsys
             Debugger.MSBF_Text("");
 
             //データ読み取り
-            for (int i = 0; i < entry; i++) {
-
+            for (int i = 0; i < entry; i++)
+            {
                 //読み取り
                 var type = CS.Byte2Short(br);
                 var unk1 = CS.Byte2Short(br);
@@ -139,10 +150,10 @@ namespace MSBT_Editor.Sectionsys
                 var unk5 = CS.Byte2Short(br);
 
                 //読み取ったデータをリストへ
-                Item.Add(new flw2_item(type,unk1,unk2,unk3,unk4,unk5));
+                Item.Add(new flw2_item(type, unk1, unk2, unk3, unk4, unk5));
 
                 //フロータイプチェックとリスト名変更さらにリストへ追加
-                var liststr = MSBF_Type_Check(type , i);
+                var liststr = MSBF_Type_Check(type, i);
                 list2.Items.Add(liststr);
 
                 //データ項目デバッグ
@@ -156,8 +167,8 @@ namespace MSBT_Editor.Sectionsys
 
             //分岐データ
             Debugger.HashTxt("//分岐番号");
-            for (int k = 0; k < (Unknown3); k+=2) {
-
+            for (int k = 0; k < (Unknown3); k += 2)
+            {
                 //読み取り
                 var b_no1 = CS.Byte2Short(br);
                 var b_no2 = CS.Byte2Short(br);
@@ -170,12 +181,12 @@ namespace MSBT_Editor.Sectionsys
                 Debugger.HashTxt(b_no1.ToString("X4"));
                 Debugger.HashTxt(b_no2.ToString("X4"));
             }
-
             //パディング読み取り
-            CS.MSBF_Padding(br,fs.Position);
+            CS.MSBF_Padding(br, fs.Position);
         }
 
-        public void Write(BinaryWriter bw, FileStream fs) {
+        public void Write(BinaryWriter bw, FileStream fs)
+        {
             long pos_sec_size, pos_flw2_offset;
             long pos_sectionend;
             FLW2 flw2 = new FLW2();
@@ -227,18 +238,16 @@ namespace MSBT_Editor.Sectionsys
             var sec_total = (int)(pos_sectionend-pos_flw2_offset);
             bw.Write(CS.StringToBytes(sec_total.ToString("X8")));
 
-
             //パディングの書き込み
             fs.Seek(pos_sectionend, SeekOrigin.Begin);
-            CS.Padding_Writer(bw,fs.Position);
-
+            CS.Padding_Writer(bw, fs.Position);
         }
 
-        public static string MSBF_Type_Check(int num , int index , bool delete_flag = false) {
+        public static string MSBF_Type_Check(int num, int index, bool delete_flag = false)
+        {
             string str = "";
-
-            
-            switch (num) {
+            switch (num)
+            {
                 case 0x0001:
                     str = Language.FLW2_List_Language(num);
                     //labeltxt25.Text = "FLW2ジャンプ先";
@@ -252,11 +261,9 @@ namespace MSBT_Editor.Sectionsys
                     //labeltxt25.Text = "固定";
                     if (delete_flag == false)
                     {
-
                         branch_list_no.Add(index);
                     }
                     //Console.WriteLine("★" + list2.Items.Count);
-
                     break;
                 case 0x0003:
                     str = Language.FLW2_List_Language(num);
@@ -279,29 +286,39 @@ namespace MSBT_Editor.Sectionsys
             return str;
         }
 
-        public static void FLW2_Item_Change(ListBox lb,TextBox tb) {
+        public static void FLW2_Item_Change(ListBox lb, TextBox tb)
+        {
             //エラー対策
-            if (lb.Items.Count == 0) return;
-            if (tb.Text.Length !=4) return ;
+            if (lb.Items.Count == 0)
+            {
+                return;
+            }
+            if (tb.Text.Length != 4)
+            {
+                return;
+            }
 
             //インデックス位置を保持
             var index = lb.SelectedIndex;
 
             //インデックス番号が-1の時0にする
-            if (index == -1) index = 0;
+            if (index == -1)
+            {
+                index = 0;
+            }
 
             //インスタンス生成
             FLW2 flw2 = new FLW2();
             FLW2.flw2_item item = flw2.Item[index];
 
-
             var numhex = Int16.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber);
-            switch (tb.Name) {
-                case "Flw2FllowTypeText":
+            //要リファクタリング　テキストボックス名リネーム時にここの編集も必要で、保守性に欠ける
+            switch (tb.Name)
+            {
+                case "txtFlw2FlowType":
                     //2以外→2
                     if (item.TypeCheck != 2 && numhex == 2)
                     {
-                        
                         //if (-1 != FLW2.branch_list_no.IndexOf(index)) return;
                         //List<int> new_branch_list_no = FLW2.branch_list_no;
 
@@ -309,7 +326,6 @@ namespace MSBT_Editor.Sectionsys
                         //Console.WriteLine(FLW2.branch_list_no.Count);
                         if (FLW2.branch_list_no != null && FLW2.branch_list_no.Count == 0)
                         {
-                            
                             lb.Items[index] = MSBF_Type_Check(numhex, index, true);
                             //Console.WriteLine(lb.Items[index]);
                             FLW2.branch_list_no.Add(index);
@@ -322,7 +338,6 @@ namespace MSBT_Editor.Sectionsys
 
                         foreach (var blnitem in FLW2.branch_list_no.Select((Value, Index) => new { Value, Index }))
                         {
-
                             //if (blnitem.Value == 0) {
                             //    //Console.WriteLine("value0 bf " + branch_no.Count);
                             //    //lb.Items[index] = MSBF_Type_Check(numhex, index, true);
@@ -349,7 +364,6 @@ namespace MSBT_Editor.Sectionsys
                             }
                             else
                             {
-                                
                                 //Console.WriteLine(lb.Items.Count);
                                 //Console.WriteLine("みつうか");
                                 //Console.WriteLine(lb.Items[index]);
@@ -381,16 +395,16 @@ namespace MSBT_Editor.Sectionsys
 
                         //lb.Items[index] = MSBF_Type_Check(numhex, index);
                         lb.SelectedIndex = index;
-
-
-
                     }
                     //2→2以外
                     else if (item.TypeCheck == 2 && numhex != 2)
                     {
                         txtb27.AppendText("2→X");
 
-                        if (-1 == FLW2.branch_list_no.IndexOf(index)) return;
+                        if (-1 == FLW2.branch_list_no.IndexOf(index))
+                        {
+                            return;
+                        }
 
                         lb.Items[index] = MSBF_Type_Check(numhex, index, true);
                         //lb.SelectedIndex = index;
@@ -415,7 +429,8 @@ namespace MSBT_Editor.Sectionsys
                         //txtb24.Text = branchpos.ToString("X4");
                         //item.Unknown5 = Convert.ToInt16(branchpos);
                     }
-                    else {
+                    else
+                    {
                         //lb.Items[index] = MSBF_Type_Check(numhex, index, true);
                         
                         //その他
@@ -423,7 +438,6 @@ namespace MSBT_Editor.Sectionsys
                         {
                             case 1:
                                 lb.Items[index] = Language.FLW2_List_Language(1);
-
                                 break;
                             case 2:
                                 lb.Items[index] = Language.FLW2_List_Language(2);
@@ -438,31 +452,25 @@ namespace MSBT_Editor.Sectionsys
                                 lb.Items[index] = "エラーデータ「正しいデータを読み込んで」";
                                 break;
                         }
-
                         item.TypeCheck = numhex;
-
                         break;
-
                     }
-                    
-
                     item.TypeCheck = numhex;
                     flw2.Item[index] = item;
-
                     break;
-                case "Flw2PaddingText":
+                case "txtFlw2Padding":
                     item.Unknown1 = numhex;
                     break;
-                case "Flw2Arg1Text":
+                case "txtFlw2Arg1":
                     item.Unknown2 = numhex;
                     break;
-                case "Flw2Arg2Text":
+                case "txtFlw2Arg2":
                     item.Unknown3 = numhex;
                     break;
-                case "Flw2Arg3Text":
+                case "txtFlw2Arg3":
                     item.Unknown4 = numhex;
                     break;
-                case "Flw2Arg4Text":
+                case "txtFlw2Arg4":
                     item.Unknown5 = numhex;
                     break;
             }
@@ -474,8 +482,8 @@ namespace MSBT_Editor.Sectionsys
             //Console.WriteLine("★" + lb.Items.Count);
         }
 
-        public static void FLW2_FlowType2_Branch(ListBox lb, TextBox tb) {
-
+        public static void FLW2_FlowType2_Branch(ListBox lb, TextBox tb)
+        {
             //Console.WriteLine("★" + lb.Items.Count);
 
             //txtb27.AppendText(Environment.NewLine+"///////////check");
@@ -483,14 +491,23 @@ namespace MSBT_Editor.Sectionsys
             //    txtb27.AppendText(Environment.NewLine + num);
 
             //エラー対策
-            if (lb.Items.Count == 0) return;
-            if (tb.Text.Length != 4) return;
+            if (lb.Items.Count == 0)
+            {
+                return;
+            }
+            if (tb.Text.Length != 4)
+            {
+                return;
+            }
 
             //リストボックスのインデックス取得
             var index = lb.SelectedIndex;
             //Console.WriteLine("///////////OK");
             //現在のインデックスがflowtype2のセクションか判別
-            if (-1 == FLW2.branch_list_no.IndexOf(index))return ;
+            if (-1 == FLW2.branch_list_no.IndexOf(index))
+            {
+                return;
+            }
             Console.WriteLine("flowtype2");
 
             //ジャンプ先1と2のインデックスを取得
@@ -498,21 +515,20 @@ namespace MSBT_Editor.Sectionsys
             branchindex1 += branchindex1;
             var branchindex2 = branchindex1 + 1;
             Console.WriteLine("★" + lb.Items.Count);
-            Console.WriteLine(branchindex1+"_"+branchindex2+"__"+ FLW2.branch_list_no.IndexOf(index));
+            Console.WriteLine(branchindex1 + "_" + branchindex2 + "__" + FLW2.branch_list_no.IndexOf(index));
             //ジャンプ先1と2の書き換え
+            //要リファクタリング　テキストボックス名リネーム時にここの編集も必要で、保守性に欠ける
             switch (tb.Name)
             {
-                case "Flw2Branch1Text":
+                case "txtFlw2BranchTrue":
                     branch_no[branchindex1] = Int16.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber);
-                    Console.WriteLine("Flw2Branch1Text__" + branch_no[branchindex1]);
-                    
+                    Console.WriteLine("txtFlw2BranchTrue__" + branch_no[branchindex1]);
                     break;
-                case "Flw2Branch2Text":
+                case "txtFlw2BranchFalse":
                     branch_no[branchindex2] = Int16.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber);
-                    Console.WriteLine("Flw2Branch2Text__" + branch_no[branchindex2] +"__"+ Int16.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber));
+                    Console.WriteLine("txtFlw2BranchFalse__" + branch_no[branchindex2] + "__" + Int16.Parse(tb.Text, System.Globalization.NumberStyles.HexNumber));
                     break;
             }
         }
-
     }
 }

--- a/MSBT_Editor/Sectionsys/LBL1.cs
+++ b/MSBT_Editor/Sectionsys/LBL1.cs
@@ -9,9 +9,10 @@ using MSBT_Editor.FileSys;
 using CS = MSBT_Editor.FileSys.Calculation_System;
 using MSBT_Editor.MSBTsys;
 using MSBT_Editor.Formsys;
+
 namespace MSBT_Editor.Sectionsys
 {
-    public class LBL1:objects
+    public class LBL1 : Objects
     {
         private static string s_magic;
         private static int s_sectionSize;
@@ -40,54 +41,60 @@ namespace MSBT_Editor.Sectionsys
             }
         }
 
-        public struct LBL_1st_Item {
+        public struct LBL_1st_Item
+        {
             public int HashSkipCounter;
             public string ListName;
             public UInt32 Hash;
-            public LBL_1st_Item(int hashSkipCounter,string listName ,UInt32 hash) {
+            public LBL_1st_Item(int hashSkipCounter, string listName, UInt32 hash)
+            {
                 this.HashSkipCounter = hashSkipCounter;
                 this.ListName = listName;
                 this.Hash = hash;
-
-
             }
         }
 
         public List<LBL_1st_Item> Item_1st;
         public List<Hash_Data> HashData;
 
-        public string Magic {
+        public string Magic
+        {
             set => s_magic = value;
             get => s_magic;
         }
 
-        public int SectionSize {
+        public int SectionSize
+        {
             set => s_sectionSize = value;
             get => s_sectionSize;
         }
 
-        public int Unknown1 {
+        public int Unknown1
+        {
             set => s_unknown1 = value;
             get => s_unknown1;
         }
 
-        public int Unknown2 {
+        public int Unknown2
+        {
             set => s_unknown2 = value;
             get => s_unknown2;
         }
 
-        public int EntrySize {
-            set {
-
-                if (value != 101 || value != 102){
+        public int EntrySize
+        {
+            set
+            {
+                if (value != 101 || value != 102)
+                {
                     s_entrySize = 101;
                 }
-                else {
+                else
+                {
                     s_entrySize = 101;
                 }
             }
             get => s_entrySize;
-
         }
 
         /// <summary>
@@ -98,8 +105,8 @@ namespace MSBT_Editor.Sectionsys
         /// </summary>
         /// <param name="br"></param>
         /// <param name="fs"></param>
-        public void Read(BinaryReader br , FileStream fs) {
-
+        public void Read(BinaryReader br, FileStream fs)
+        {
             MsbtListBox.Items.Clear();
             
             BeginEntryAdressList = new List<long>();
@@ -117,25 +124,24 @@ namespace MSBT_Editor.Sectionsys
 
             //LBL1のベースアドレスを記憶 Stores the base address of LBL1
             s_positionBaseAddress = fs.Position - 4;
-            ReadEntrySection(fs,br);
+            ReadEntrySection(fs, br);
 
             s_positionLastEntrySection = fs.Position;
-
 
             //配列を用意エントリー数を超える場合があるので最大値を0xFFにしています
             //The maximum value is set to 0xFF because the number of entries in the array may be exceeded.
             string[] NameArray = new string[0xFF];
-            ReadLabelSection(fs,br,ref NameArray);
-
+            ReadLabelSection(fs, br, ref NameArray);
 
             var Tmp = MsbtListBoxIndexList;
             IOrderedEnumerable<int> MsbtListBoxIndexSorted = Tmp.OrderBy(x => x);
 
             int count = MsbtListBoxIndexList.Count;
-            for (int l = 0; l < count; l++) 
+            for (int l = 0; l < count; l++)
+            {
                 MsbtListBox.Items.Add(NameArray[l]);
-
-            CS.Padding(br,fs.Position);
+            }
+            CS.Padding(br, fs.Position);
         }
 
         /// <summary>
@@ -144,21 +150,22 @@ namespace MSBT_Editor.Sectionsys
         /// </summary>
         /// <param name="fs"></param>
         /// <param name="br"></param>
-        private void ReadEntrySection(FileStream fs , BinaryReader br) {
-            
+        private void ReadEntrySection(FileStream fs, BinaryReader br)
+        {
             for (int i = 0; i < EntrySize; i++)
             {
-
                 BeginEntryAdressList.Add(fs.Position);
 
                 var SkipIntNum = CS.Byte2Int(br);
                 var NameOffsetIntNum = CS.Byte2Int(br);
 
-
                 HashSkipList.Add(SkipIntNum);
                 NameOffsetList.Add(NameOffsetIntNum);
 
-                if (i == 0) continue;
+                if (i == 0)
+                {
+                    continue;
+                }
 
                 var BeforeNameOffsetIndex = NameOffsetList.Count() - 2;
                 var NowNameOffsetIndex = NameOffsetList.Count() - 1;
@@ -181,11 +188,9 @@ namespace MSBT_Editor.Sectionsys
         /// <param name="fs"></param>
         /// <param name="br"></param>
         /// <param name="NameArray"></param>
-        private void ReadLabelSection(FileStream fs , BinaryReader br , ref string[] NameArray) {
-
+        private void ReadLabelSection(FileStream fs, BinaryReader br, ref string[] NameArray)
+        {
             var PositionNameSectionBytesSize = (s_positionBaseAddress + s_sectionSize) - s_positionLastEntrySection;
-
-
 
             //LBL1セクションのラベル名セクションの処理
             for (long k = 0; k < PositionNameSectionBytesSize; k++)
@@ -195,23 +200,21 @@ namespace MSBT_Editor.Sectionsys
                 var LabelString            = CS.Byte2Char(br, LabelStringSize);
                 var LabelMsbtListBoxIndex  = CS.Byte2Int(br);
 
-                
-
                 NameArray[LabelMsbtListBoxIndex] = LabelString;
 
                 var NameOffset          = (int)(PositionFirstLabelName - s_positionBaseAddress);
                 var FindNameOffsetIndex = NameOffsetList.IndexOf(NameOffset);
 
                 if (-1 != FindNameOffsetIndex)
+                {
                     NameList.Add(LabelString);
+                }
 
                 MsbtListBoxIndexList.Add(LabelMsbtListBoxIndex);
 
                 //文字数のカウント分と末尾のInt32(4byte)分進める
                 k += LabelStringSize;
                 k += 4;
-
-
             }
         }
         /// <summary>
@@ -219,22 +222,23 @@ namespace MSBT_Editor.Sectionsys
         /// </summary>
         /// <param name="bw"></param>
         /// <param name="fs"></param>
-        public void Write(BinaryWriter bw , FileStream fs) {
-
+        public void Write(BinaryWriter bw, FileStream fs)
+        {
             List<long> PositionIndividualLabelTop = new List<long>();
             HashData = new List<Hash_Data>();
 
             var PositionEntrySizeAddress = fs.Position + 4;
 
-
-            if (EntrySize <= 101) EntrySize = 101;
-
+            if (EntrySize <= 101)
+            {
+                EntrySize = 101;
+            }
 
             //ヘッダー情報の書き込み
-            CS.String_Writer(bw ,"LBL1");
+            CS.String_Writer(bw,"LBL1");
             CS.Null_Writer_Int32(bw, 3);
 
-            CS.StringToBytesWriter(bw,(EntrySize).ToString("X8"));
+            CS.StringToBytesWriter(bw, (EntrySize).ToString("X8"));
 
             s_positionBaseAddress = fs.Position - 4;
 
@@ -245,7 +249,7 @@ namespace MSBT_Editor.Sectionsys
             var HashDataArray = LabelHashAndListIndexSortToArray(HashData);
 
             //ラベルセクションを書き込む
-            LabelSectionWriter(fs,bw,HashDataArray,ref PositionIndividualLabelTop);
+            LabelSectionWriter(fs, bw, HashDataArray, ref PositionIndividualLabelTop);
             var PositionLabelLastAddress = fs.Position;
 
             CS.Padding_Writer(bw, fs.Position);
@@ -255,12 +259,11 @@ namespace MSBT_Editor.Sectionsys
             fs.Seek(s_positionBaseAddress + 4, SeekOrigin.Begin);
 
             //データセクションに計算したデータを書き込む
-            DataSectionAllWriter(bw,HashDataArray,PositionIndividualLabelTop, PositionLabelLastAddress);
-
+            DataSectionAllWriter(bw, HashDataArray, PositionIndividualLabelTop, PositionLabelLastAddress);
 
             SectionSize = (int)(PositionLabelLastAddress - s_positionBaseAddress);
             fs.Seek(PositionEntrySizeAddress, SeekOrigin.Begin);
-            CS.StringToBytesWriter(bw,SectionSize.ToString("X8"));
+            CS.StringToBytesWriter(bw, SectionSize.ToString("X8"));
             fs.Seek(PositionLBL1LastAddress, SeekOrigin.Begin);
         }
         /// <summary>
@@ -270,7 +273,8 @@ namespace MSBT_Editor.Sectionsys
         /// <param name="HashDataArray"></param>
         /// <param name="PositionIndividualLabelTop"></param>
         /// <param name="PositionLabelLastAddress"></param>
-        private void DataSectionAllWriter(BinaryWriter bw , Hash_Data[] HashDataArray,List<long> PositionIndividualLabelTop,long PositionLabelLastAddress/*, ref int ActualDataCount*/) {
+        private void DataSectionAllWriter(BinaryWriter bw, Hash_Data[] HashDataArray, List<long> PositionIndividualLabelTop, long PositionLabelLastAddress/*, ref int ActualDataCount*/)
+        {
             var ActualDataCount = 0;
             int count = HashData.Count();
             for (int i = 0; i < count; i++)
@@ -295,7 +299,9 @@ namespace MSBT_Editor.Sectionsys
                     if ((count - 1) != i)
                     {
                         if (HashDataArray[i + 1].Hash - NowHash == 0)
+                        {
                             continue;
+                        }
                     }
                 }
 
@@ -305,19 +311,17 @@ namespace MSBT_Editor.Sectionsys
             DataSectionInsufficientDataWriter(bw, PositionLabelLastAddress, ActualDataCount);
         }
 
-
         /// <summary>
         /// データセクションの不足データをパディングまでのオフセットで埋めます。
         /// </summary>
         /// <param name="bw"></param>
         /// <param name="PositionLabelLastAddress"></param>
         /// <param name="ActualDataCount"></param>
-        private void DataSectionInsufficientDataWriter(BinaryWriter bw,long PositionLabelLastAddress,int ActualDataCount) {
+        private void DataSectionInsufficientDataWriter(BinaryWriter bw, long PositionLabelLastAddress, int ActualDataCount)
+        {
             if (ActualDataCount < EntrySize)
             {
-
                 var NumberOfInsufficientData = EntrySize - ActualDataCount;
-
 
                 for (int a = 0; a < NumberOfInsufficientData; a++)
                 {
@@ -335,16 +339,17 @@ namespace MSBT_Editor.Sectionsys
         /// <param name="LabelOffset"></param>
         /// <param name="ActualDataCount"></param>
         /// <param name="isTop"></param>
-        private void DataSectionActualDataWriter(BinaryWriter bw , uint hash , int SkipDataCount , int LabelOffset ,ref int ActualDataCount , bool isTop) {
+        private void DataSectionActualDataWriter(BinaryWriter bw, uint hash, int SkipDataCount, int LabelOffset, ref int ActualDataCount, bool isTop)
+        {
             var LoopCountChange = 0;
             var BranchDataChenge = -1;
-            if (isTop) {
+            if (isTop)
+            {
                 LoopCountChange = 1;
                 BranchDataChenge = 0;
             }
             for (int j = 0; j < (hash + LoopCountChange); j++)
             {
-
                 if (j == hash + BranchDataChenge)
                 {
                     CS.StringToBytesWriter(bw, (SkipDataCount).ToString("X8"));
@@ -363,29 +368,29 @@ namespace MSBT_Editor.Sectionsys
         /// </summary>
         /// <param name="bw"></param>
         /// <param name="nullSetNum"></param>
-        private void TemporarilyWriteNullData(BinaryWriter bw , int nullSetNum = 2) {
+        private void TemporarilyWriteNullData(BinaryWriter bw, int nullSetNum = 2)
+        {
             //ラベルindex(不明)とラベルオフセットを空白で埋める
-
             for (int i = 0; i < EntrySize; i++)
-
+            {
                 CS.Null_Writer_Int32(bw, nullSetNum);
+            }
         }
 
         /// <summary>
         /// ラベルとMSBTリストのインデックス値のリストデータを取得します
         /// </summary>
         /// <returns></returns>
-        private List<Hash_Data> LabelHashAndListIndexGet() {
+        private List<Hash_Data> LabelHashAndListIndexGet()
+        {
             //ラベルのエリアの値を書き込む
             List<Hash_Data> TemporarilyData = new List<Hash_Data>();
             int itemcount = 0;
             foreach (var item in MsbtListBox.Items)
             {
-
                 var LabelName = item.ToString();
                 //var strnum = (byte)str.Count();
                 //ハッシュ値とリスト番号をリストへ
-
                 var LabelHash = CS.MSBT_Hash(LabelName, EntrySize);
 
                 TemporarilyData.Add(new Hash_Data(LabelHash, itemcount));
@@ -398,9 +403,9 @@ namespace MSBT_Editor.Sectionsys
         /// </summary>
         /// <param name="HashData"></param>
         /// <returns></returns>
-        private Hash_Data[] LabelHashAndListIndexSortToArray(List<Hash_Data> HashData) {
-            IOrderedEnumerable<Hash_Data> HashDataSorted
-                    = HashData.OrderBy(x => x.Hash);
+        private Hash_Data[] LabelHashAndListIndexSortToArray(List<Hash_Data> HashData)
+        {
+            IOrderedEnumerable<Hash_Data> HashDataSorted = HashData.OrderBy(x => x.Hash);
             return HashDataSorted.ToArray();
         }
         /// <summary>
@@ -410,7 +415,8 @@ namespace MSBT_Editor.Sectionsys
         /// <param name="bw"></param>
         /// <param name="HashDataArray"></param>
         /// <param name="PositionIndividualLabelTop"></param>
-        private void LabelSectionWriter(FileStream fs , BinaryWriter bw , Hash_Data[] HashDataArray , ref List<long> PositionIndividualLabelTop) {
+        private void LabelSectionWriter(FileStream fs, BinaryWriter bw, Hash_Data[] HashDataArray, ref List<long> PositionIndividualLabelTop)
+        {
             int hashcount = 0;
             foreach (var hashdatsorted in HashDataArray)
             {
@@ -427,5 +433,4 @@ namespace MSBT_Editor.Sectionsys
             }
         }
     }
-
 }

--- a/MSBT_Editor/Sectionsys/TXT2.cs
+++ b/MSBT_Editor/Sectionsys/TXT2.cs
@@ -8,9 +8,10 @@ using MSBT_Editor.FileSys;
 using CS = MSBT_Editor.FileSys.Calculation_System;
 using MSBT_Editor.MSBTsys;
 using MSBT_Editor.Formsys;
+
 namespace MSBT_Editor.Sectionsys
 {
-    class TXT2:objects
+    class TXT2 : Objects
     {
         public string magic;
         public int sec_size;
@@ -19,9 +20,9 @@ namespace MSBT_Editor.Sectionsys
         public static int entries;
         public List<long> txt_pos;
         public static List<string> Text_Data;
-        
 
-        public void Read(BinaryReader br,FileStream fs ) {
+        public void Read(BinaryReader br, FileStream fs)
+        {
             txt_pos = new List<long>();
             Text_Data = new List<string>();
 
@@ -35,7 +36,8 @@ namespace MSBT_Editor.Sectionsys
             var offset = fs.Position;
 
             //テキストオフセットの位置を読み込む
-            for (int i = 0; i < entries; i++){
+            for (int i = 0; i < entries; i++)
+            {
                 txt_pos.Add((int)offset + CS.Byte2Int(br));
             }
 
@@ -43,13 +45,15 @@ namespace MSBT_Editor.Sectionsys
             var offset2 = fs.Position;
 
             //テキストを読み込む
-            for(int j = 0; j<entries; j++) {
+            for(int j = 0; j<entries; j++)
+            {
                 fs.Position = txt_pos[j]-4;
                 Text_Data.Add(CS.Byte2JIS(br, fs));
             }
         }
 
-        public void Write(BinaryWriter bw , FileStream fs, long fileend_pos) {
+        public void Write(BinaryWriter bw, FileStream fs, long fileend_pos)
+        {
             bw.Write(Encoding.ASCII.GetBytes("TXT2"));
             var txt2_sec_pos = fs.Position;
             CS.Null_Writer_Int32(bw, 3);
@@ -59,7 +63,9 @@ namespace MSBT_Editor.Sectionsys
             var txt2_txt_offset_pos = fs.Position;
             int count = MsbtListBox.Items.Count;
             for (int i = 0; i < count; i++)
+            {
                 CS.Null_Writer_Int32(bw);
+            }
 
             List<int> txt2_offset_data = new List<int>();
             for (int j = 0; j < count; j++)
@@ -71,7 +77,6 @@ namespace MSBT_Editor.Sectionsys
 
             var txt2_txt_end = fs.Position;
 
-
             CS.Padding_Writer(bw, fs.Position);
             var msbt_end_pos = fs.Position;
 
@@ -80,7 +85,9 @@ namespace MSBT_Editor.Sectionsys
 
             fs.Seek(txt2_txt_offset_pos, SeekOrigin.Begin);
             for (int i = 0; i < count; i++)
+            {
                 bw.Write(CS.StringToInt32_byte(txt2_offset_data[i].ToString("X8")));
+            }
 
             fs.Seek(fileend_pos, SeekOrigin.Begin);
             bw.Write(CS.StringToInt32_byte(((int)msbt_end_pos).ToString("X8")));


### PR DESCRIPTION
## 概要
- テキストボックスによるFEN1, FLW2の引数変更を行ったときに、変更後の値がインスタンス変数に代入されない不具合を修正
- 字下げスタイルをAllmanスタイルに統一

## 不具合詳細
#24 で、FEN1とFLW2の引数を格納するテキストボックスのコントロール名をリネームしたことに起因する不具合
#28 と同じメカニズムであるため省略

## 変更内容
switch文におけるcase文字列を、それぞれ現在のコントロール名に変更